### PR TITLE
#144 #155 Rollup관련 배앤드 로직 프론트 api와 파라미터 누락으로 재머지신청

### DIFF
--- a/backend/src/apis/rollup.py
+++ b/backend/src/apis/rollup.py
@@ -32,11 +32,14 @@ _actionRouter = APIRouter()
     summary="List subsidiaries available for DMA precheck rollup",
 )
 async def listSubsidiariesRoute(
-    runId: int = Query(...),
+    runId: Optional[int] = Query(None),
+    sourceCycleId: Optional[int] = Query(None),
+    rollupPurposeCode: Optional[str] = Query("DMA_PRECHECK"),
+    metricScopeCode: Optional[str] = Query("G0_02_FINANCIAL_BASIS"),
     userModel=Depends(get_token),
 ):
     try:
-        return listSubsidiaries(runId, userModel)
+        return listSubsidiaries(runId, sourceCycleId, rollupPurposeCode, metricScopeCode, userModel)
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e))
     except RollupError as e:
@@ -85,9 +88,13 @@ async def calcBatchRoute(batchId: int, userModel=Depends(get_token)):
     response_model=RollupRequestResponseDto,
     summary="List rollup transfer requests for current source company",
 )
-async def listRequestsRoute(userModel=Depends(get_token)):
+async def listRequestsRoute(
+    rollupPurposeCode: Optional[str] = Query("DMA_PRECHECK"),
+    metricScopeCode: Optional[str] = Query("G0_02_FINANCIAL_BASIS"),
+    userModel=Depends(get_token)
+):
     try:
-        return listRequests(userModel)
+        return listRequests(rollupPurposeCode, metricScopeCode, userModel)
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e))
     except RollupError as e:

--- a/backend/src/services/onboardings/service.py
+++ b/backend/src/services/onboardings/service.py
@@ -42,10 +42,10 @@ SUPPORTED_CYCLE_TYPE = "PRE_DMA_G0"
 SUPPORTED_INPUT_CYCLE_TYPES = {CYCLE_TYPE_PRE_DMA_G0, CYCLE_TYPE_POST_DMA_DISCLOSURE}
 SUPPORTED_ASSIGNMENT_CYCLE_TYPES = {CYCLE_TYPE_PRE_DMA_G0, CYCLE_TYPE_POST_DMA_DISCLOSURE}
 ASSIGNMENT_MANAGER_ROLES = {"ADMIN", "ESG"}
-ASSIGNMENT_MANAGER_ROLE_NAMES = {"관리자", "ESG담당자"}
+ASSIGNMENT_MANAGER_ROLE_NAMES = {"관리자", "ESG담당자", "ESG 담당자"}
 PRE_DMA_G0_CYCLE_NOT_READY_MESSAGE = "PRE_DMA_G0_CYCLE_NOT_READY: 기존 PRE_DMA_G0 workflow를 먼저 시작해 주세요."
 APPROVER_ROLES = {"ADMIN", "ESG"}
-APPROVER_ROLE_NAMES = {"관리자", "ESG담당자"}
+APPROVER_ROLE_NAMES = {"관리자", "ESG담당자", "ESG 담당자"}
 
 
 class PreDmaG0CycleNotReadyError(ValueError):
@@ -682,5 +682,14 @@ def readUserField(userModel, key: str):
     if userModel is None:
         return None
     if isinstance(userModel, dict):
-        return userModel.get(key)
-    return getattr(userModel, key, None)
+        if key in userModel:
+            return userModel.get(key)
+        if key == "role_name":
+            return userModel.get("roleName")
+        return None
+    value = getattr(userModel, key, None)
+    if value is not None:
+        return value
+    if key == "role_name":
+        return getattr(userModel, "roleName", None)
+    return None

--- a/backend/src/services/rollups/service.py
+++ b/backend/src/services/rollups/service.py
@@ -311,11 +311,15 @@ def calcBatch(batchId: int, userModel) -> RollupCalculateResponseDto:
             rules, ruleSources = rollupRepository.resolveConsolidatedRuleClosure(metricIds)
             requiredAtomicIds = rollupRepository.resolveExternalEntitySourceAtomicIdsTx(cur, batchId)
 
-            facts = rollupRepository.listApprovedFactsByCompany(includedCompanyIds, reportingYear, requiredAtomicIds)
-            currentFactMap = rollupCalculator.buildMultiCompanyFactMap(includedCompanyIds, requiredAtomicIds, facts)
-
-            priorFacts = rollupRepository.listPriorYearApprovedFactsByCompany(includedCompanyIds, reportingYear, requiredAtomicIds)
-            priorFactMap = rollupCalculator.buildMultiCompanyFactMap(includedCompanyIds, requiredAtomicIds, priorFacts)
+            historicalDepth = rollupCalculator.resolveHistoricalLookbackDepth(rules, ruleSources)
+            entityFactMapsByYear = {}
+            for factYear in range(reportingYear, reportingYear - historicalDepth - 1, -1):
+                facts = rollupRepository.listApprovedFactsByCompany(includedCompanyIds, factYear, requiredAtomicIds)
+                entityFactMapsByYear[factYear] = rollupCalculator.buildMultiCompanyFactMap(
+                    includedCompanyIds,
+                    requiredAtomicIds,
+                    facts,
+                )
 
             cur.execute("SELECT id FROM ESG_MATERIALITY_RUN WHERE required_rollup_batch_id = ?", (batchId,))
             r = cur.fetchone()
@@ -323,9 +327,12 @@ def calcBatch(batchId: int, userModel) -> RollupCalculateResponseDto:
             if purposeCode == rollupRepository.ROLLUP_PURPOSE_DMA_PRECHECK and not runId:
                 raise RollupError(409, "REPORT_RUN_NOT_FOUND", "Report workflow run was not found for rollup batch.")
 
-            from src.utils.rollupcalculator import calculateConsolidatedRules
-            results, warnings, allSuccess = calculateConsolidatedRules(
-                rules, ruleSources, currentFactMap, priorFactMap, includedCompanyIds
+            results, warnings, allSuccess = rollupCalculator.calculateConsolidatedRulesByYear(
+                rules=rules,
+                sources=ruleSources,
+                entityFactMapsByYear=entityFactMapsByYear,
+                reportingYear=reportingYear,
+                companyIds=includedCompanyIds,
             )
 
             if not allSuccess:

--- a/backend/src/utils/rollupcalculator.py
+++ b/backend/src/utils/rollupcalculator.py
@@ -1,13 +1,17 @@
-﻿from __future__ import annotations
-from typing import Any
+from __future__ import annotations
+
+from collections import defaultdict
+from decimal import Decimal
+from typing import Any, Optional
 
 from src.utils.calculationengine import (
-    normalizeSources,
-    groupSourcesByRule,
-    calculateRule,
     STATUS_CALCULATED,
+    calculateRule,
+    groupSourcesByRule,
+    normalizeSources,
     topologicalSortRules,
 )
+
 
 class CalculationError(Exception):
     def __init__(self, code: str, message: str):
@@ -15,7 +19,7 @@ class CalculationError(Exception):
         self.code = code
         self.message = message
 
-# Supported formulas
+
 FORMULA_ROLLUP_SUM = "ROLLUP_SUM"
 FORMULA_ROLLUP_REFERENCE_COPY = "ROLLUP_REFERENCE_COPY"
 FORMULA_ROLLUP_ADD = "ROLLUP_ADD"
@@ -24,31 +28,37 @@ FORMULA_ROLLUP_DIVIDE = "ROLLUP_DIVIDE"
 FORMULA_ROLLUP_YOY_DIFF = "ROLLUP_YOY_DIFF"
 FORMULA_ROLLUP_YOY_RATE = "ROLLUP_YOY_RATE"
 
-def _aggregateSum(factsByCompany: dict[int, float|int|str]) -> float|int:
-    from decimal import Decimal
+
+def _aggregateSum(factsByCompany: dict[int, float | int | str]) -> float | int:
     total = Decimal("0")
-    for val in factsByCompany.values():
-        if val is None:
+    for value in factsByCompany.values():
+        if value is None:
             continue
-        total += Decimal(str(val))
+        total += Decimal(str(value))
     if total == total.to_integral_value():
         return int(total)
     return float(total)
 
-def _aggregateReference(factsByCompany: dict[int, Any], ruleCode: str) -> Any:
-    distinct_values = set()
-    first_val = None
-    for val in factsByCompany.values():
-        if val is not None:
-            distinct_values.add(str(val))
-            if first_val is None:
-                first_val = val
 
-    if len(distinct_values) == 0:
+def _aggregateReference(factsByCompany: dict[int, Any], code: str) -> Any:
+    distinctValues = set()
+    firstValue = None
+    for value in factsByCompany.values():
+        if value is None:
+            continue
+        distinctValues.add(str(value))
+        if firstValue is None:
+            firstValue = value
+
+    if len(distinctValues) == 0:
         return None
-    if len(distinct_values) > 1:
-        raise CalculationError(f"CALCULATION_REFERENCE_VALUE_AMBIGUOUS", f"Rule {ruleCode} reference values differ across companies")
-    return first_val
+    if len(distinctValues) > 1:
+        raise CalculationError(
+            "CALCULATION_REFERENCE_VALUE_AMBIGUOUS",
+            f"Rule {code} reference values differ across companies",
+        )
+    return firstValue
+
 
 def buildSourceTrace(sourceCompanyValuesTrace: dict[str, dict]) -> dict:
     return {
@@ -58,6 +68,7 @@ def buildSourceTrace(sourceCompanyValuesTrace: dict[str, dict]) -> dict:
         }
         for atomicId, companyValues in sourceCompanyValuesTrace.items()
     }
+
 
 def buildMultiCompanyFactMap(
     companyIds: list[int],
@@ -78,8 +89,7 @@ def buildMultiCompanyFactMap(
             continue
         if allowedAtomicMetricIds and atomicMetricId not in allowedAtomicMetricIds:
             continue
-        key = (companyId, atomicMetricId)
-        factMap[key] = {
+        factMap[(companyId, atomicMetricId)] = {
             "companyId": companyId,
             "atomicMetricId": atomicMetricId,
             "valueNumeric": fact.get("valueNumeric") if fact.get("valueNumeric") is not None else fact.get("value_numeric"),
@@ -88,164 +98,370 @@ def buildMultiCompanyFactMap(
         }
     return factMap
 
+
 def calculateConsolidatedRules(
     rules: list[dict],
     sources: list[dict],
     currentFactsMap: dict[tuple[int, str], dict],
     priorFactsMap: dict[tuple[int, str], dict],
-    companyIds: list[int]
+    companyIds: list[int],
+) -> tuple[list[dict], list[dict], bool]:
+    return calculateConsolidatedRulesByYear(
+        rules=rules,
+        sources=sources,
+        entityFactMapsByYear={0: currentFactsMap or {}, -1: priorFactsMap or {}},
+        reportingYear=0,
+        companyIds=companyIds,
+    )
+
+
+def resolveHistoricalLookbackDepth(rules: list[dict], sources: list[dict]) -> int:
+    ruleByCode = {ruleCode(rule): rule for rule in rules or [] if ruleCode(rule)}
+    producerByAtomicId = {
+        targetAtomicMetricId(rule): ruleCode(rule)
+        for rule in rules or []
+        if targetAtomicMetricId(rule) and ruleCode(rule)
+    }
+    sourceByRule = groupSourcesByRule(normalizeSources(sources))
+    memo = {}
+
+    def atomicDepth(atomicId: str, stack: set[str]) -> int:
+        producerCode = producerByAtomicId.get(atomicId)
+        if not producerCode:
+            return 0
+        return ruleDepth(producerCode, stack)
+
+    def ruleDepth(code: str, stack: set[str]) -> int:
+        if code in memo:
+            return memo[code]
+        if code in stack:
+            raise ValueError("CALCULATION_RULE_CYCLE")
+        stack.add(code)
+        rule = ruleByCode.get(code)
+        if not rule:
+            stack.remove(code)
+            return 0
+
+        depth = 0
+        ruleSources = sourceByRule.get(code) or []
+        if isYoyFormula(rule):
+            currentSources, priorSources = splitYoySources(ruleSources)
+            for source in currentSources:
+                depth = max(depth, atomicDepth(source["sourceAtomicMetricId"], stack))
+            for source in priorSources:
+                depth = max(depth, 1 + atomicDepth(source["sourceAtomicMetricId"], stack))
+        else:
+            for source in ruleSources:
+                depth = max(depth, atomicDepth(source["sourceAtomicMetricId"], stack))
+        stack.remove(code)
+        memo[code] = depth
+        return depth
+
+    return max((ruleDepth(code, set()) for code in ruleByCode), default=0)
+
+
+def calculateConsolidatedRulesByYear(
+    rules: list[dict],
+    sources: list[dict],
+    entityFactMapsByYear: dict[int, dict[tuple[int, str], dict]],
+    reportingYear: int,
+    companyIds: list[int],
 ) -> tuple[list[dict], list[dict], bool]:
     normalizedSources = normalizeSources(sources)
     groupedSources = groupSourcesByRule(normalizedSources)
+    ruleByCode = {ruleCode(rule): rule for rule in rules or [] if ruleCode(rule)}
+    producerByAtomicId = {
+        targetAtomicMetricId(rule): ruleCode(rule)
+        for rule in rules or []
+        if targetAtomicMetricId(rule) and ruleCode(rule)
+    }
+
     try:
         orderedRules = topologicalSortRules(rules, normalizedSources)
-    except ValueError as e:
-        return [], [{"ruleCode": "GRAPH", "error": str(e), "message": str(e)}], False
+        historicalLookbackDepth = resolveHistoricalLookbackDepth(rules, normalizedSources)
+    except ValueError as error:
+        return [], [{"ruleCode": "GRAPH", "error": str(error), "message": str(error)}], False
+
+    consolidatedFactMapsByYear: dict[int, dict[str, dict]] = defaultdict(dict)
+    atomicMemo: dict[tuple[int, str], dict] = {}
+    ruleMemo: dict[tuple[int, str], dict] = {}
+    activeRuleStack: set[tuple[int, str]] = set()
+
+    def evaluateAtomicAtYear(atomicId: str, year: int, contextRule: Optional[dict] = None) -> dict:
+        memoKey = (int(year), atomicId)
+        producerCode = producerByAtomicId.get(atomicId)
+        if producerCode:
+            if memoKey not in atomicMemo:
+                produced = evaluateRuleAtYear(producerCode, year)
+                if produced.get("calculationStatus") != STATUS_CALCULATED:
+                    atomicMemo[memoKey] = {
+                        "status": produced.get("calculationStatus") or "CALCULATION_SOURCE_NOT_READY",
+                        "fact": None,
+                        "trace": {
+                            "atomicMetricId": atomicId,
+                            "evaluatedYear": year,
+                            "producerRuleCode": producerCode,
+                            "producerStatus": produced.get("calculationStatus"),
+                            "producerTrace": produced.get("calculationTrace"),
+                        },
+                    }
+                else:
+                    atomicMemo[memoKey] = {
+                        "status": STATUS_CALCULATED,
+                        "fact": {
+                            "atomicMetricId": atomicId,
+                            "valueNumeric": produced.get("valueNumeric"),
+                            "valueText": produced.get("valueText"),
+                            "unit": produced.get("unit"),
+                        },
+                        "trace": {
+                            "atomicMetricId": atomicId,
+                            "evaluatedYear": year,
+                            "producerRuleCode": producerCode,
+                            "valueNumeric": produced.get("valueNumeric"),
+                        },
+                    }
+            return atomicMemo[memoKey]
+
+        return aggregateEntityFactsAtYear(
+            atomicId=atomicId,
+            year=year,
+            companyIds=companyIds,
+            entityFactMapsByYear=entityFactMapsByYear,
+            rule=contextRule,
+        )
+
+    def evaluateRuleAtYear(code: str, year: int) -> dict:
+        memoKey = (int(year), code)
+        if memoKey in ruleMemo:
+            return ruleMemo[memoKey]
+        if memoKey in activeRuleStack:
+            result = buildRuleResult(ruleByCode.get(code), [], "CALCULATION_RULE_CYCLE", year)
+            ruleMemo[memoKey] = result
+            return result
+
+        rule = ruleByCode.get(code)
+        if not rule:
+            result = buildRuleResult({}, [], "CALCULATION_SOURCE_NOT_READY", year)
+            ruleMemo[memoKey] = result
+            return result
+
+        activeRuleStack.add(memoKey)
+        ruleSources = groupedSources.get(code) or []
+        engineFactMap = {}
+        enginePriorFactMap = {}
+        sourceCompanyValuesTrace = {}
+        dependencyTrace = []
+
+        if isYoyFormula(rule):
+            currentSources, priorSources = splitYoySources(ruleSources)
+            for source in currentSources:
+                sourceResult = evaluateAtomicAtYear(source["sourceAtomicMetricId"], year, rule)
+                dependencyTrace.append(traceSource(source, sourceResult, year, "current"))
+                if sourceResult["status"] == STATUS_CALCULATED:
+                    engineFactMap[source["sourceAtomicMetricId"]] = normalizeEngineFact(sourceResult["fact"])
+                    sourceCompanyValuesTrace[source["sourceAtomicMetricId"]] = sourceCompanyValues(sourceResult)
+            for source in priorSources:
+                sourceResult = evaluateAtomicAtYear(source["sourceAtomicMetricId"], year - 1, rule)
+                dependencyTrace.append(traceSource(source, sourceResult, year - 1, "prior"))
+                if sourceResult["status"] == STATUS_CALCULATED:
+                    enginePriorFactMap[source["sourceAtomicMetricId"]] = normalizeEngineFact(sourceResult["fact"])
+        else:
+            for source in ruleSources:
+                sourceResult = evaluateAtomicAtYear(source["sourceAtomicMetricId"], year, rule)
+                dependencyTrace.append(traceSource(source, sourceResult, year, "current"))
+                if sourceResult["status"] == STATUS_CALCULATED:
+                    engineFactMap[source["sourceAtomicMetricId"]] = normalizeEngineFact(sourceResult["fact"])
+                    sourceCompanyValuesTrace[source["sourceAtomicMetricId"]] = sourceCompanyValues(sourceResult)
+
+        engineResult = calculateRule(rule, ruleSources, engineFactMap, enginePriorFactMap)
+        result = buildRuleResult(rule, ruleSources, engineResult.get("calculationStatus"), year)
+        result.update(
+            {
+                "valueNumeric": engineResult.get("valueNumeric"),
+                "valueText": engineResult.get("valueText"),
+                "unit": engineResult.get("unit"),
+                "sourceCompanyValues": buildSourceTrace(sourceCompanyValuesTrace),
+                "calculationTrace": {
+                    "reportingYear": reportingYear,
+                    "evaluatedYear": year,
+                    "historicalLookbackDepth": historicalLookbackDepth,
+                    "currentPreAggregatedMap": engineFactMap,
+                    "priorPreAggregatedMap": enginePriorFactMap,
+                    "historicalDependencies": dependencyTrace,
+                    "engineTrace": engineResult.get("calculationTrace"),
+                },
+            }
+        )
+
+        if result["calculationStatus"] == STATUS_CALCULATED:
+            consolidatedFactMapsByYear[int(year)][result["groupAtomicMetricId"]] = {
+                "atomicMetricId": result["groupAtomicMetricId"],
+                "valueNumeric": result.get("valueNumeric"),
+                "valueText": result.get("valueText"),
+                "unit": result.get("unit"),
+            }
+
+        activeRuleStack.remove(memoKey)
+        ruleMemo[memoKey] = result
+        return result
 
     results = []
     warnings = []
-    consolidatedFactMap = {}
-
     for rule in orderedRules:
-        ruleCode = rule.get("calculation_rule_code") or rule.get("ruleCode")
-        ruleSources = groupedSources.get(ruleCode) or []
-        try:
-            res = _calculateConsolidatedRule(
-                rule,
-                ruleSources,
-                currentFactsMap,
-                priorFactsMap,
-                companyIds,
-                consolidatedFactMap,
-            )
-            results.append(res)
-            consolidatedFactMap[res["groupAtomicMetricId"]] = {
-                "atomicMetricId": res["groupAtomicMetricId"],
-                "valueNumeric": res.get("valueNumeric"),
-                "valueText": res.get("valueText"),
-                "unit": res.get("unit"),
-            }
-        except CalculationError as e:
-            warnings.append({"ruleCode": ruleCode, "error": e.code, "message": str(e)})
-            return results, warnings, False
-        except Exception as e:
-            warnings.append({"ruleCode": ruleCode, "error": "CALCULATION_ENGINE_ERROR", "message": str(e)})
+        code = ruleCode(rule)
+        result = evaluateRuleAtYear(code, reportingYear)
+        results.append(result)
+        if result.get("calculationStatus") != STATUS_CALCULATED:
+            errorCode = result.get("calculationStatus") or "CALCULATION_ENGINE_ERROR"
+            warnings.append({"ruleCode": code, "error": errorCode, "message": errorCode})
             return results, warnings, False
 
     return results, warnings, True
 
-def _calculateConsolidatedRule(
-    rule: dict,
-    ruleSources: list[dict],
-    currentFactsMap: dict[tuple[int, str], dict],
-    priorFactsMap: dict[tuple[int, str], dict],
+
+def aggregateEntityFactsAtYear(
+    *,
+    atomicId: str,
+    year: int,
     companyIds: list[int],
-    consolidatedFactMap: dict[str, dict],
+    entityFactMapsByYear: dict[int, dict[tuple[int, str], dict]],
+    rule: Optional[dict],
 ) -> dict:
-    ruleCode = rule["calculation_rule_code"]
-    formula = str(rule.get("formula_type")).upper()
-    targetAtomicId = rule["target_atomic_metric_id"]
-
-    sourceAtomicIds = [s["sourceAtomicMetricId"] for s in ruleSources]
-
-    def getValue(fact: dict) -> Any:
-        if fact.get("valueNumeric") is not None:
-            return fact.get("valueNumeric")
-        if fact.get("value_numeric") is not None:
-            return fact.get("value_numeric")
-        if fact.get("valueText") is not None:
-            return fact.get("valueText")
-        return fact.get("value_text")
-
-    def getCompanyValues(atomicId: str, fmap: dict, isPrior: bool = False) -> dict[int, Any]:
-        cv = {}
-        for cid in companyIds:
-            f = fmap.get((cid, atomicId))
-            value = getValue(f) if f else None
-            if value is None:
-                raise CalculationError("CALCULATION_SOURCE_NOT_READY", f"Rule {ruleCode} missing source {atomicId} for company {cid} (prior={isPrior})")
-            cv[cid] = value
-        return cv
-
-    def getSourceValue(atomicId: str, fmap: dict) -> tuple[Any, dict]:
-        consolidatedFact = consolidatedFactMap.get(atomicId)
-        if consolidatedFact:
-            value = getValue(consolidatedFact)
-            if value is None:
-                raise CalculationError("CALCULATION_SOURCE_NOT_READY", f"Rule {ruleCode} missing consolidated source {atomicId}")
-            return value, {"__group__": value}
-        companyValues = getCompanyValues(atomicId, fmap)
-        return _aggregateSum(companyValues), companyValues
-
-    if formula == FORMULA_ROLLUP_REFERENCE_COPY:
-        if len(ruleSources) == 0:
-            raise CalculationError("CALCULATION_SOURCE_NOT_READY", f"Rule {ruleCode} has no sources")
-        if len(ruleSources) > 1:
-            raise CalculationError("CALCULATION_REFERENCE_SOURCE_AMBIGUOUS", f"Rule {ruleCode} has multiple distinct semantic sources")
-
-        atomicId = ruleSources[0]["sourceAtomicMetricId"]
-        consolidatedFact = consolidatedFactMap.get(atomicId)
-        if consolidatedFact:
-            val = getValue(consolidatedFact)
-            cv = {"__group__": val}
+    factsForYear = entityFactMapsByYear.get(int(year), {})
+    companyValues = {}
+    missingCompanyIds = []
+    for companyId in companyIds:
+        fact = factsForYear.get((int(companyId), atomicId))
+        value = getFactValue(fact) if fact else None
+        if value is None:
+            missingCompanyIds.append(int(companyId))
         else:
-            cv = getCompanyValues(atomicId, currentFactsMap)
-            val = _aggregateReference(cv, ruleCode)
-        if val is None:
-            raise CalculationError("CALCULATION_SOURCE_NOT_READY", f"Rule {ruleCode} source missing or null")
+            companyValues[int(companyId)] = value
 
-        is_numeric = isinstance(val, (int, float))
+    if missingCompanyIds:
         return {
-            "groupMetricId": rule.get("metric_id"),
-            "groupAtomicMetricId": targetAtomicId,
-            "sourceAtomicMetricIds": sourceAtomicIds,
-            "formulaType": formula,
-            "valueNumeric": val if is_numeric else None,
-            "valueText": str(val) if not is_numeric else None,
-            "sourceCompanyValues": buildSourceTrace({atomicId: cv}),
+            "status": "CALCULATION_SOURCE_NOT_READY",
+            "fact": None,
+            "trace": {
+                "atomicMetricId": atomicId,
+                "evaluatedYear": year,
+                "missingCompanyIds": missingCompanyIds,
+                "sourceCompanyValues": companyValues,
+            },
         }
 
-    engineFactMap = {}
-    sourceCompanyValuesTrace = {}
+    formula = str((rule or {}).get("formula_type") or "").upper()
+    if formula == FORMULA_ROLLUP_REFERENCE_COPY:
+        value = _aggregateReference(companyValues, ruleCode(rule or {}))
+    else:
+        value = _aggregateSum(companyValues)
+    numericYn = isinstance(value, (int, float))
+    return {
+        "status": STATUS_CALCULATED,
+        "fact": {
+            "atomicMetricId": atomicId,
+            "valueNumeric": value if numericYn else None,
+            "valueText": None if numericYn else str(value),
+            "unit": None,
+        },
+        "trace": {
+            "atomicMetricId": atomicId,
+            "evaluatedYear": year,
+            "valueNumeric": value if numericYn else None,
+            "sourceCompanyValues": companyValues,
+        },
+    }
 
-    for s in ruleSources:
-        atomicId = s["sourceAtomicMetricId"]
-        sourceValue, cv = getSourceValue(atomicId, currentFactsMap)
-        engineFactMap[atomicId] = {"value_numeric": sourceValue}
-        if atomicId not in sourceCompanyValuesTrace:
-            sourceCompanyValuesTrace[atomicId] = cv
 
-    enginePriorFactMap = {}
-    if formula in (FORMULA_ROLLUP_YOY_DIFF, FORMULA_ROLLUP_YOY_RATE):
-        for s in ruleSources:
-            atomicId = s["sourceAtomicMetricId"]
-            cv_prior = getCompanyValues(atomicId, priorFactsMap, isPrior=True)
-            sumValPrior = _aggregateSum(cv_prior)
-            enginePriorFactMap[atomicId] = {"value_numeric": sumValPrior}
+def buildRuleResult(rule: Optional[dict], ruleSources: list[dict], status: str, year: int) -> dict:
+    return {
+        "groupMetricId": (rule or {}).get("metric_id"),
+        "groupAtomicMetricId": targetAtomicMetricId(rule or {}),
+        "sourceAtomicMetricIds": [source["sourceAtomicMetricId"] for source in ruleSources],
+        "formulaType": str((rule or {}).get("formula_type") or "").upper(),
+        "valueNumeric": None,
+        "valueText": None,
+        "unit": (rule or {}).get("output_unit") or (rule or {}).get("unit"),
+        "sourceCompanyValues": {},
+        "calculationStatus": status,
+        "calculationTrace": {"evaluatedYear": year},
+    }
 
-    try:
-        engineResult = calculateRule(rule, ruleSources, engineFactMap, enginePriorFactMap)
 
-        if engineResult.get("calculationStatus") != STATUS_CALCULATED:
-            raise CalculationError(
-                engineResult.get("calculationStatus") or "CALCULATION_ERROR",
-                engineResult.get("warning") or f"Calculation failed for rule {ruleCode}"
-            )
+def normalizeEngineFact(fact: dict) -> dict:
+    return {
+        "value_numeric": fact.get("valueNumeric") if fact.get("valueNumeric") is not None else fact.get("value_numeric"),
+        "value_text": fact.get("valueText") if fact.get("valueText") is not None else fact.get("value_text"),
+        "unit": fact.get("unit"),
+    }
 
-        return {
-            "groupMetricId": rule.get("metric_id"),
-            "groupAtomicMetricId": targetAtomicId,
-            "sourceAtomicMetricIds": sourceAtomicIds,
-            "formulaType": formula,
-            "valueNumeric": engineResult.get("valueNumeric"),
-            "valueText": engineResult.get("valueText"),
-            "unit": engineResult.get("unit"),
-            "sourceCompanyValues": buildSourceTrace(sourceCompanyValuesTrace),
-            "calculationTrace": {"preAggregatedMap": engineFactMap, "priorPreAggregatedMap": enginePriorFactMap, "engineTrace": engineResult.get("calculationTrace")}
-        }
-    except CalculationError as e:
-        raise e
-    except Exception as e:
-        raise CalculationError("CALCULATION_ENGINE_ERROR", str(e))
 
-__all__ = ["buildMultiCompanyFactMap", "calculateConsolidatedRules", "CalculationError"]
+def sourceCompanyValues(sourceResult: dict) -> dict:
+    trace = sourceResult.get("trace") or {}
+    if trace.get("sourceCompanyValues") is not None:
+        return trace["sourceCompanyValues"]
+    fact = sourceResult.get("fact") or {}
+    return {"__group__": fact.get("valueNumeric")}
+
+
+def traceSource(source: dict, sourceResult: dict, year: int, sourceTiming: str) -> dict:
+    trace = sourceResult.get("trace") or {}
+    fact = sourceResult.get("fact") or {}
+    return {
+        "sourceAtomicMetricId": source.get("sourceAtomicMetricId"),
+        "sourceRole": source.get("sourceRole"),
+        "sourceTiming": sourceTiming,
+        "evaluatedYear": year,
+        "status": sourceResult.get("status"),
+        "valueNumeric": fact.get("valueNumeric"),
+        "sourceCompanyValues": trace.get("sourceCompanyValues"),
+        "missingCompanyIds": trace.get("missingCompanyIds"),
+        "producerRuleCode": trace.get("producerRuleCode"),
+    }
+
+
+def isYoyFormula(rule: dict) -> bool:
+    return str(rule.get("formula_type") or rule.get("formulaType") or "").upper() in {
+        FORMULA_ROLLUP_YOY_DIFF,
+        FORMULA_ROLLUP_YOY_RATE,
+    }
+
+
+def splitYoySources(sources: list[dict]) -> tuple[list[dict], list[dict]]:
+    currentSources = [source for source in sources if source["sourceRole"] == "CURRENT"]
+    if not currentSources and sources:
+        currentSources = [sources[0]]
+    priorSources = [source for source in sources if source["sourceRole"] == "PRIOR"]
+    if not priorSources:
+        priorSources = currentSources
+    return currentSources, priorSources
+
+
+def ruleCode(rule: dict) -> str:
+    return str(rule.get("calculation_rule_code") or rule.get("ruleCode") or "").strip()
+
+
+def targetAtomicMetricId(rule: dict) -> str:
+    return str(rule.get("target_atomic_metric_id") or rule.get("targetAtomicMetricId") or "").strip()
+
+
+def getFactValue(fact: Optional[dict]) -> Any:
+    if not fact:
+        return None
+    if fact.get("valueNumeric") is not None:
+        return fact.get("valueNumeric")
+    if fact.get("value_numeric") is not None:
+        return fact.get("value_numeric")
+    if fact.get("valueText") is not None:
+        return fact.get("valueText")
+    return fact.get("value_text")
+
+
+__all__ = [
+    "buildMultiCompanyFactMap",
+    "calculateConsolidatedRules",
+    "calculateConsolidatedRulesByYear",
+    "resolveHistoricalLookbackDepth",
+    "CalculationError",
+]

--- a/backend/tests/test_rollupcalculator.py
+++ b/backend/tests/test_rollupcalculator.py
@@ -476,6 +476,125 @@ class RollupCalculatorTest(unittest.TestCase):
         )
         self.assertEqual(cur.executeCount, 1)
 
+    def test_single_level_yoy_diff_uses_prior_consolidated_target(self):
+        rules = [
+            rule("R1", "T1", "ROLLUP_ADD", order=10),
+            rule("R2", "T2", "ROLLUP_YOY_DIFF", order=20),
+        ]
+        sources = [
+            source("R1", "S1", sourceId=1),
+            source("R2", "T1", "CURRENT", sourceId=2),
+        ]
+        results, warnings, success = calculator.calculateConsolidatedRulesByYear(
+            rules,
+            sources,
+            {
+                2026: factMap([fact(1, "S1", 10), fact(2, "S1", 20)]),
+                2025: factMap([fact(1, "S1", 5), fact(2, "S1", 15)]),
+            },
+            2026,
+            [1, 2],
+        )
+        self.assertTrue(success, warnings)
+        self.assertEqual([item["valueNumeric"] for item in results], [30, 10])
+
+    def test_single_level_yoy_rate_uses_prior_consolidated_target(self):
+        rules = [
+            rule("R1", "T1", "ROLLUP_ADD", order=10),
+            rule("R2", "T2", "ROLLUP_YOY_RATE", order=20),
+        ]
+        sources = [
+            source("R1", "S1", sourceId=1),
+            source("R2", "T1", "CURRENT", sourceId=2),
+        ]
+        results, warnings, success = calculator.calculateConsolidatedRulesByYear(
+            rules,
+            sources,
+            {
+                2026: factMap([fact(1, "S1", 10), fact(2, "S1", 20)]),
+                2025: factMap([fact(1, "S1", 5), fact(2, "S1", 15)]),
+            },
+            2026,
+            [1, 2],
+        )
+        self.assertTrue(success, warnings)
+        self.assertEqual(results[1]["valueNumeric"], 50)
+
+    def test_two_level_chained_yoy_resolves_year_two_history(self):
+        rules = [
+            rule("R1", "T1", "ROLLUP_ADD", order=10),
+            rule("R2", "T2", "ROLLUP_YOY_DIFF", order=20),
+            rule("R3", "T3", "ROLLUP_YOY_RATE", order=30),
+        ]
+        sources = [
+            source("R1", "S1", sourceId=1),
+            source("R2", "T1", "CURRENT", sourceId=2),
+            source("R3", "T2", "CURRENT", sourceId=3),
+        ]
+        results, warnings, success = calculator.calculateConsolidatedRulesByYear(
+            rules,
+            sources,
+            {
+                2026: factMap([fact(1, "S1", 10), fact(2, "S1", 20)]),
+                2025: factMap([fact(1, "S1", 5), fact(2, "S1", 15)]),
+                2024: factMap([fact(1, "S1", 3), fact(2, "S1", 7)]),
+            },
+            2026,
+            [1, 2],
+        )
+        self.assertTrue(success, warnings)
+        self.assertEqual([item["valueNumeric"] for item in results], [30, 10, 0])
+        self.assertEqual(calculator.resolveHistoricalLookbackDepth(rules, sources), 2)
+        self.assertEqual(results[2]["calculationTrace"]["historicalLookbackDepth"], 2)
+
+    def test_missing_year_two_raw_fact_blocks_calculation(self):
+        rules = [
+            rule("R1", "T1", "ROLLUP_ADD", order=10),
+            rule("R2", "T2", "ROLLUP_YOY_DIFF", order=20),
+            rule("R3", "T3", "ROLLUP_YOY_RATE", order=30),
+        ]
+        sources = [
+            source("R1", "S1", sourceId=1),
+            source("R2", "T1", "CURRENT", sourceId=2),
+            source("R3", "T2", "CURRENT", sourceId=3),
+        ]
+        _, warnings, success = calculator.calculateConsolidatedRulesByYear(
+            rules,
+            sources,
+            {
+                2026: factMap([fact(1, "S1", 10), fact(2, "S1", 20)]),
+                2025: factMap([fact(1, "S1", 5), fact(2, "S1", 15)]),
+            },
+            2026,
+            [1, 2],
+        )
+        self.assertFalse(success)
+        self.assertIn("CALCULATION_SOURCE_NOT_READY", warnings[0]["error"])
+
+    def test_reporting_year_result_only_with_historical_trace(self):
+        rules = [
+            rule("R1", "T1", "ROLLUP_ADD", order=10),
+            rule("R2", "T2", "ROLLUP_YOY_DIFF", order=20),
+        ]
+        sources = [
+            source("R1", "S1", sourceId=1),
+            source("R2", "T1", "CURRENT", sourceId=2),
+        ]
+        results, warnings, success = calculator.calculateConsolidatedRulesByYear(
+            rules,
+            sources,
+            {
+                2026: factMap([fact(1, "S1", 10), fact(2, "S1", 20)]),
+                2025: factMap([fact(1, "S1", 5), fact(2, "S1", 15)]),
+            },
+            2026,
+            [1, 2],
+        )
+        self.assertTrue(success, warnings)
+        self.assertEqual(len(results), 2)
+        self.assertEqual([item["calculationTrace"]["evaluatedYear"] for item in results], [2026, 2026])
+        self.assertEqual(results[1]["calculationTrace"]["historicalDependencies"][1]["evaluatedYear"], 2025)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## #️⃣연관된 이슈

> #145 #144 

## 📝작업 내용

> #145 이 Rollup 오류 머지 후 프론트에서 요구하는 파라미터 또한 누락이 되어 재 머지 합니다

프론트는 아직 ONBOARDING_ASSIGNMENT_ROOT = "/onboardingAssignment"를 호출합니다.
백엔드는 Fastset 파일명 기반 legacy route /onboardingAssignment와 canonical /api/v1/onboarding-assignments 둘 다 살아있는 구조라, URL 자체가 404 원인으로 보이진 않습니다.
더 가능성 높은 원인은 role guard였습니다. 기존에는 "ESG담당자"만 허용하고 "ESG 담당자"는 막힐 수 있었습니다. 이 부분을 보정했습니다.