### PR TITLE
백앤드 지표 CALCULATION ERROR NORMALIZATION 완료 

### DIFF
--- a/backend/src/utils/rollupcalculator.py
+++ b/backend/src/utils/rollupcalculator.py
@@ -304,13 +304,14 @@ def calculateConsolidatedRulesByYear(
                 }
 
         except CalculationError as error:
-            result = buildRuleResult(rule, [], error.code, year)
+            result = buildRuleResult(rule, ruleSources, error.code, year)
             result["calculationTrace"] = {
                 "reportingYear": reportingYear,
                 "evaluatedYear": year,
                 "historicalLookbackDepth": historicalLookbackDepth,
                 "errorCode": error.code,
                 "errorMessage": error.message,
+                "historicalDependencies": dependencyTrace,
             }
 
         finally:

--- a/backend/src/utils/rollupcalculator.py
+++ b/backend/src/utils/rollupcalculator.py
@@ -247,62 +247,75 @@ def calculateConsolidatedRulesByYear(
             return result
 
         activeRuleStack.add(memoKey)
-        ruleSources = groupedSources.get(code) or []
-        engineFactMap = {}
-        enginePriorFactMap = {}
-        sourceCompanyValuesTrace = {}
-        dependencyTrace = []
+        try:
+            ruleSources = groupedSources.get(code) or []
+            engineFactMap = {}
+            enginePriorFactMap = {}
+            sourceCompanyValuesTrace = {}
+            dependencyTrace = []
 
-        if isYoyFormula(rule):
-            currentSources, priorSources = splitYoySources(ruleSources)
-            for source in currentSources:
-                sourceResult = evaluateAtomicAtYear(source["sourceAtomicMetricId"], year, rule)
-                dependencyTrace.append(traceSource(source, sourceResult, year, "current"))
-                if sourceResult["status"] == STATUS_CALCULATED:
-                    engineFactMap[source["sourceAtomicMetricId"]] = normalizeEngineFact(sourceResult["fact"])
-                    sourceCompanyValuesTrace[source["sourceAtomicMetricId"]] = sourceCompanyValues(sourceResult)
-            for source in priorSources:
-                sourceResult = evaluateAtomicAtYear(source["sourceAtomicMetricId"], year - 1, rule)
-                dependencyTrace.append(traceSource(source, sourceResult, year - 1, "prior"))
-                if sourceResult["status"] == STATUS_CALCULATED:
-                    enginePriorFactMap[source["sourceAtomicMetricId"]] = normalizeEngineFact(sourceResult["fact"])
-        else:
-            for source in ruleSources:
-                sourceResult = evaluateAtomicAtYear(source["sourceAtomicMetricId"], year, rule)
-                dependencyTrace.append(traceSource(source, sourceResult, year, "current"))
-                if sourceResult["status"] == STATUS_CALCULATED:
-                    engineFactMap[source["sourceAtomicMetricId"]] = normalizeEngineFact(sourceResult["fact"])
-                    sourceCompanyValuesTrace[source["sourceAtomicMetricId"]] = sourceCompanyValues(sourceResult)
+            if isYoyFormula(rule):
+                currentSources, priorSources = splitYoySources(ruleSources)
+                for source in currentSources:
+                    sourceResult = evaluateAtomicAtYear(source["sourceAtomicMetricId"], year, rule)
+                    dependencyTrace.append(traceSource(source, sourceResult, year, "current"))
+                    if sourceResult["status"] == STATUS_CALCULATED:
+                        engineFactMap[source["sourceAtomicMetricId"]] = normalizeEngineFact(sourceResult["fact"])
+                        sourceCompanyValuesTrace[source["sourceAtomicMetricId"]] = sourceCompanyValues(sourceResult)
+                for source in priorSources:
+                    sourceResult = evaluateAtomicAtYear(source["sourceAtomicMetricId"], year - 1, rule)
+                    dependencyTrace.append(traceSource(source, sourceResult, year - 1, "prior"))
+                    if sourceResult["status"] == STATUS_CALCULATED:
+                        enginePriorFactMap[source["sourceAtomicMetricId"]] = normalizeEngineFact(sourceResult["fact"])
+            else:
+                for source in ruleSources:
+                    sourceResult = evaluateAtomicAtYear(source["sourceAtomicMetricId"], year, rule)
+                    dependencyTrace.append(traceSource(source, sourceResult, year, "current"))
+                    if sourceResult["status"] == STATUS_CALCULATED:
+                        engineFactMap[source["sourceAtomicMetricId"]] = normalizeEngineFact(sourceResult["fact"])
+                        sourceCompanyValuesTrace[source["sourceAtomicMetricId"]] = sourceCompanyValues(sourceResult)
 
-        engineResult = calculateRule(rule, ruleSources, engineFactMap, enginePriorFactMap)
-        result = buildRuleResult(rule, ruleSources, engineResult.get("calculationStatus"), year)
-        result.update(
-            {
-                "valueNumeric": engineResult.get("valueNumeric"),
-                "valueText": engineResult.get("valueText"),
-                "unit": engineResult.get("unit"),
-                "sourceCompanyValues": buildSourceTrace(sourceCompanyValuesTrace),
-                "calculationTrace": {
-                    "reportingYear": reportingYear,
-                    "evaluatedYear": year,
-                    "historicalLookbackDepth": historicalLookbackDepth,
-                    "currentPreAggregatedMap": engineFactMap,
-                    "priorPreAggregatedMap": enginePriorFactMap,
-                    "historicalDependencies": dependencyTrace,
-                    "engineTrace": engineResult.get("calculationTrace"),
-                },
+            engineResult = calculateRule(rule, ruleSources, engineFactMap, enginePriorFactMap)
+            result = buildRuleResult(rule, ruleSources, engineResult.get("calculationStatus"), year)
+            result.update(
+                {
+                    "valueNumeric": engineResult.get("valueNumeric"),
+                    "valueText": engineResult.get("valueText"),
+                    "unit": engineResult.get("unit"),
+                    "sourceCompanyValues": buildSourceTrace(sourceCompanyValuesTrace),
+                    "calculationTrace": {
+                        "reportingYear": reportingYear,
+                        "evaluatedYear": year,
+                        "historicalLookbackDepth": historicalLookbackDepth,
+                        "currentPreAggregatedMap": engineFactMap,
+                        "priorPreAggregatedMap": enginePriorFactMap,
+                        "historicalDependencies": dependencyTrace,
+                        "engineTrace": engineResult.get("calculationTrace"),
+                    },
+                }
+            )
+
+            if result["calculationStatus"] == STATUS_CALCULATED:
+                consolidatedFactMapsByYear[int(year)][result["groupAtomicMetricId"]] = {
+                    "atomicMetricId": result["groupAtomicMetricId"],
+                    "valueNumeric": result.get("valueNumeric"),
+                    "valueText": result.get("valueText"),
+                    "unit": result.get("unit"),
+                }
+
+        except CalculationError as error:
+            result = buildRuleResult(rule, [], error.code, year)
+            result["calculationTrace"] = {
+                "reportingYear": reportingYear,
+                "evaluatedYear": year,
+                "historicalLookbackDepth": historicalLookbackDepth,
+                "errorCode": error.code,
+                "errorMessage": error.message,
             }
-        )
 
-        if result["calculationStatus"] == STATUS_CALCULATED:
-            consolidatedFactMapsByYear[int(year)][result["groupAtomicMetricId"]] = {
-                "atomicMetricId": result["groupAtomicMetricId"],
-                "valueNumeric": result.get("valueNumeric"),
-                "valueText": result.get("valueText"),
-                "unit": result.get("unit"),
-            }
+        finally:
+            activeRuleStack.discard(memoKey)
 
-        activeRuleStack.remove(memoKey)
         ruleMemo[memoKey] = result
         return result
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#156

## 📝작업 내용

수정 파일
backend/src/utils/rollupcalculator.py 단 1개

커밋 1 — a819d0b (HOTFIX: CalculationError Normalize)
문제
ROLLUP_REFERENCE_COPY에서 회사별 값이 다를 때 _aggregateReference()가 CalculationError를 raise → evaluateRuleAtYear() 밖으로 전파 → unittest error / API 500 가능

수정 내용

python
# Before
activeRuleStack.add(memoKey)
# ... 계산 로직 ...
activeRuleStack.remove(memoKey)   # 예외 시 실행 안 됨
# After
activeRuleStack.add(memoKey)
try:
    # ... 계산 로직 ...
except CalculationError as error:
    result = buildRuleResult(rule, ruleSources, error.code, year)
    result["calculationTrace"] = { "errorCode": ..., "errorMessage": ... }
finally:
    activeRuleStack.discard(memoKey)  # 예외와 무관하게 항상 정리
효과

CalculationError → exception 전파 없이 warnings[0]["error"] == "CALCULATION_REFERENCE_VALUE_AMBIGUOUS", success == False 반환
remove → discard (finally) 로 변경하여 예외 안전성 확보
커밋 2 — 17c6871 (HOTFIX-R1: Source Trace 보존)
문제
catch 블록에서 buildRuleResult(rule, [], ...) 로 sourceAtomicMetricIds가 빈 배열이 되고, dependencyTrace도 유실 → 관측성 저하

수정 내용

python
# Before
result = buildRuleResult(rule, [], error.code, year)
result["calculationTrace"] = {
    "errorCode": error.code,
    "errorMessage": error.message,
}
# After
result = buildRuleResult(rule, ruleSources, error.code, year)  # ← [] → ruleSources
result["calculationTrace"] = {
    "errorCode": error.code,
    "errorMessage": error.message,
    "historicalDependencies": dependencyTrace,               # ← 추가
}