### PR TITLE
 ROLLUP 계산 오류 안전 처리/전년 대비 탄소 감소/증가량 YoY 증감 방향 설정 기능 연결

### DIFF
--- a/backend/src/utils/calculationengine.py
+++ b/backend/src/utils/calculationengine.py
@@ -28,6 +28,9 @@ FORMULA_ROLLUP_YOY_RATE = "ROLLUP_YOY_RATE"
 ZERO_DIVISION_RETURN_NULL_AND_FLAG = "RETURN_NULL_AND_FLAG"
 ZERO_DIVISION_NOT_APPLICABLE = "NOT_APPLICABLE"
 
+YOY_DIRECTION_CURRENT_MINUS_PRIOR = "CURRENT_MINUS_PRIOR"
+YOY_DIRECTION_PRIOR_MINUS_CURRENT = "PRIOR_MINUS_CURRENT"
+
 ROUNDING_2DP = "ROUND_2DP"
 ROUNDING_0 = "ROUND_0"
 
@@ -193,7 +196,14 @@ def calculateYoy(
     priorValue = sum(priorValues)
     if rateYn and priorValue == 0:
         return zeroDivision(base, priorSources)
-    value = ((currentValue - priorValue) / priorValue * 100) if rateYn else currentValue - priorValue
+
+    directionCode = normalizeYoyDirection(base.get("yoyDirectionCode"))
+    delta = (
+        priorValue - currentValue
+        if directionCode == YOY_DIRECTION_PRIOR_MINUS_CURRENT
+        else currentValue - priorValue
+    )
+    value = (delta / priorValue * 100) if rateYn else delta
     return calculated(
         base,
         valueNumeric=applyRounding(value, base.get("roundingPolicy")),
@@ -201,6 +211,10 @@ def calculateYoy(
         trace={
             "currentAtomicMetricIds": [source["sourceAtomicMetricId"] for source in currentSources],
             "priorAtomicMetricIds": [source["sourceAtomicMetricId"] for source in priorSources],
+            "yoyDirectionCode": directionCode,
+            "currentValue": currentValue,
+            "priorValue": priorValue,
+            "delta": delta,
         },
     )
 
@@ -425,7 +439,17 @@ def buildResultBase(rule: dict, formulaType: str) -> dict:
         "formulaType": formulaType,
         "zeroDivisionPolicy": rule.get("zero_division_policy") or rule.get("zeroDivisionPolicy"),
         "roundingPolicy": rule.get("rounding_policy") or rule.get("roundingPolicy"),
+        "yoyDirectionCode": normalizeYoyDirection(
+            rule.get("yoy_direction_code") or rule.get("yoyDirectionCode")
+        ),
     }
+
+
+def normalizeYoyDirection(value: Optional[str]) -> str:
+    normalized = str(value or "").strip().upper()
+    if normalized == YOY_DIRECTION_PRIOR_MINUS_CURRENT:
+        return YOY_DIRECTION_PRIOR_MINUS_CURRENT
+    return YOY_DIRECTION_CURRENT_MINUS_PRIOR
 
 
 def applyRounding(value: float, roundingPolicy: Optional[str]) -> float:
@@ -473,6 +497,9 @@ __all__ = [
     "STATUS_SOURCE_NOT_READY",
     "STATUS_ZERO_DIVISION",
     "STATUS_NOT_APPLICABLE",
+    "YOY_DIRECTION_CURRENT_MINUS_PRIOR",
+    "YOY_DIRECTION_PRIOR_MINUS_CURRENT",
+    "normalizeYoyDirection",
     "calculateRules",
     "calculateRule",
     "resolveAffectedRuleGraph",

--- a/backend/src/utils/calculationrepository.py
+++ b/backend/src/utils/calculationrepository.py
@@ -322,7 +322,8 @@ def listAffectedRules(
             cr.rounding_policy,
             cr.result_table,
             cr.output_unit,
-            cr.execution_order
+            cr.execution_order,
+            cr.yoy_direction_code
         FROM ESG_CALCULATION_RULE cr
         JOIN ESG_CALCULATION_RULE_SOURCE src
           ON src.calculation_rule_code = cr.calculation_rule_code
@@ -361,7 +362,8 @@ def listAffectedRulesTx(
             cr.rounding_policy,
             cr.result_table,
             cr.output_unit,
-            cr.execution_order
+            cr.execution_order,
+            cr.yoy_direction_code
         FROM ESG_CALCULATION_RULE cr
         JOIN ESG_CALCULATION_RULE_SOURCE src
           ON src.calculation_rule_code = cr.calculation_rule_code

--- a/backend/src/utils/calculationrepository.py
+++ b/backend/src/utils/calculationrepository.py
@@ -31,7 +31,8 @@ def listActiveRules(
             rounding_policy,
             result_table,
             output_unit,
-            execution_order
+            execution_order,
+            yoy_direction_code
         FROM ESG_CALCULATION_RULE
         WHERE UPPER(COALESCE(execution_scope, '')) = ?
           AND active_yn = 1
@@ -64,7 +65,8 @@ def listActiveRulesTx(
             rounding_policy,
             result_table,
             output_unit,
-            execution_order
+            execution_order,
+            yoy_direction_code
         FROM ESG_CALCULATION_RULE
         WHERE UPPER(COALESCE(execution_scope, '')) = ?
           AND active_yn = 1
@@ -100,7 +102,8 @@ def listActiveRulesByTargetAtomicIds(
             rounding_policy,
             result_table,
             output_unit,
-            execution_order
+            execution_order,
+            yoy_direction_code
         FROM ESG_CALCULATION_RULE
         WHERE UPPER(COALESCE(execution_scope, '')) = ?
           AND active_yn = 1
@@ -136,7 +139,8 @@ def listActiveRulesByTargetAtomicIdsTx(
             rounding_policy,
             result_table,
             output_unit,
-            execution_order
+            execution_order,
+            yoy_direction_code
         FROM ESG_CALCULATION_RULE
         WHERE UPPER(COALESCE(execution_scope, '')) = ?
           AND active_yn = 1

--- a/backend/tests/test_calculationengine.py
+++ b/backend/tests/test_calculationengine.py
@@ -374,6 +374,91 @@ class CalculationEngineTest(unittest.TestCase):
         )
         self.assertEqual(result["calculationStatus"], engine.STATUS_REFERENCE_SOURCE_AMBIGUOUS)
 
+    # ── Step 12-C2-R3 YOY direction tests ──
+
+    def _yoyRule(self, code, target, formula, direction=None):
+        r = rule(code, target, formula)
+        if direction is not None:
+            r["yoy_direction_code"] = direction
+        return r
+
+    def test_yoy_direction_default_missing_is_current_minus_prior(self):
+        """direction 미지정 → CURRENT_MINUS_PRIOR → current=90,prior=100 → diff=-10"""
+        result = firstResult(
+            [self._yoyRule("R1", "M__D1", "ENTITY_YOY_DIFF")],
+            [source("R1", "M__Q1", "CURRENT")],
+            [fact("M__Q1", 90)],
+            [fact("M__Q1", 100)],
+        )
+        self.assertEqual(result["calculationStatus"], engine.STATUS_CALCULATED)
+        self.assertEqual(result["valueNumeric"], -10)
+        self.assertEqual(result["calculationTrace"]["yoyDirectionCode"], engine.YOY_DIRECTION_CURRENT_MINUS_PRIOR)
+
+    def test_yoy_current_minus_prior_diff(self):
+        """CURRENT_MINUS_PRIOR diff: current=90,prior=100 → -10"""
+        result = firstResult(
+            [self._yoyRule("R1", "M__D1", "ENTITY_YOY_DIFF", "CURRENT_MINUS_PRIOR")],
+            [source("R1", "M__Q1", "CURRENT")],
+            [fact("M__Q1", 90)],
+            [fact("M__Q1", 100)],
+        )
+        self.assertEqual(result["valueNumeric"], -10)
+
+    def test_yoy_current_minus_prior_rate(self):
+        """CURRENT_MINUS_PRIOR rate: current=90,prior=100 → -10"""
+        result = firstResult(
+            [self._yoyRule("R1", "M__D1", "ENTITY_YOY_RATE", "CURRENT_MINUS_PRIOR")],
+            [source("R1", "M__Q1", "CURRENT")],
+            [fact("M__Q1", 90)],
+            [fact("M__Q1", 100)],
+        )
+        self.assertEqual(result["valueNumeric"], -10)
+
+    def test_yoy_prior_minus_current_diff(self):
+        """PRIOR_MINUS_CURRENT diff: current=90,prior=100 → 10"""
+        result = firstResult(
+            [self._yoyRule("R1", "M__D1", "ENTITY_YOY_DIFF", "PRIOR_MINUS_CURRENT")],
+            [source("R1", "M__Q1", "CURRENT")],
+            [fact("M__Q1", 90)],
+            [fact("M__Q1", 100)],
+        )
+        self.assertEqual(result["valueNumeric"], 10)
+        self.assertEqual(result["calculationTrace"]["yoyDirectionCode"], engine.YOY_DIRECTION_PRIOR_MINUS_CURRENT)
+
+    def test_yoy_prior_minus_current_rate(self):
+        """PRIOR_MINUS_CURRENT rate: current=90,prior=100 → 10"""
+        result = firstResult(
+            [self._yoyRule("R1", "M__D1", "ENTITY_YOY_RATE", "PRIOR_MINUS_CURRENT")],
+            [source("R1", "M__Q1", "CURRENT")],
+            [fact("M__Q1", 90)],
+            [fact("M__Q1", 100)],
+        )
+        self.assertEqual(result["valueNumeric"], 10)
+
+    def test_entity_yoy_diff_direction_metadata(self):
+        """ENTITY_YOY_DIFF: trace에 currentValue/priorValue/delta 포함"""
+        result = firstResult(
+            [self._yoyRule("R1", "M__D1", "ENTITY_YOY_DIFF", "CURRENT_MINUS_PRIOR")],
+            [source("R1", "M__Q1", "CURRENT")],
+            [fact("M__Q1", 90)],
+            [fact("M__Q1", 100)],
+        )
+        trace = result["calculationTrace"]
+        self.assertEqual(trace["currentValue"], 90)
+        self.assertEqual(trace["priorValue"], 100)
+        self.assertEqual(trace["delta"], -10)
+
+    def test_rollup_yoy_diff_direction_metadata(self):
+        """ROLLUP_YOY_DIFF: PRIOR_MINUS_CURRENT direction metadata 적용"""
+        result = firstResult(
+            [self._yoyRule("R1", "M__D1", "ROLLUP_YOY_DIFF", "PRIOR_MINUS_CURRENT")],
+            [source("R1", "M__Q1", "CURRENT")],
+            [fact("M__Q1", 90)],
+            [fact("M__Q1", 100)],
+        )
+        self.assertEqual(result["valueNumeric"], 10)
+        self.assertEqual(result["calculationTrace"]["yoyDirectionCode"], engine.YOY_DIRECTION_PRIOR_MINUS_CURRENT)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_rollupcalculator.py
+++ b/backend/tests/test_rollupcalculator.py
@@ -595,6 +595,32 @@ class RollupCalculatorTest(unittest.TestCase):
         self.assertEqual([item["calculationTrace"]["evaluatedYear"] for item in results], [2026, 2026])
         self.assertEqual(results[1]["calculationTrace"]["historicalDependencies"][1]["evaluatedYear"], 2025)
 
+    # ── Step 12-C2-R3 ROLLUP YOY direction tests ──
+
+    def test_rollup_yoy_diff_prior_minus_current(self):
+        """ROLLUP_YOY_DIFF + PRIOR_MINUS_CURRENT: current=90,prior=100 → 10"""
+        r = rule("R1", "T1", "ROLLUP_YOY_DIFF")
+        r["yoy_direction_code"] = "PRIOR_MINUS_CURRENT"
+        results, warnings, success = calculate(
+            [r],
+            [source("R1", "S1", "CURRENT")],
+            [fact(1, "S1", 45), fact(2, "S1", 45)],
+            [fact(1, "S1", 50), fact(2, "S1", 50)],
+        )
+        self.assertTrue(success, warnings)
+        self.assertEqual(results[0]["valueNumeric"], 10)
+
+    def test_rollup_yoy_diff_current_minus_prior_default(self):
+        """ROLLUP_YOY_DIFF direction 미지정 → CURRENT_MINUS_PRIOR → current=90,prior=100 → -10"""
+        results, warnings, success = calculate(
+            [rule("R1", "T1", "ROLLUP_YOY_DIFF")],
+            [source("R1", "S1", "CURRENT")],
+            [fact(1, "S1", 45), fact(2, "S1", 45)],
+            [fact(1, "S1", 50), fact(2, "S1", 50)],
+        )
+        self.assertTrue(success, warnings)
+        self.assertEqual(results[0]["valueNumeric"], -10)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## #️⃣연관된 이슈

> #156

## 📝작업 내용

1. ROLLUP 계산 오류 안전 처리 (Hotfix)
문제 상황 롤업 계산 중 회사별로 참조값이 서로 다를 경우(예: A사 = 5, B사 = 10), 시스템이 예외를 밖으로 던져버려 테스트 실패 및 API 500 오류가 발생할 수 있었습니다.

수정 내용

예외가 터져도 시스템이 조용히 멈추지 않고, "이 규칙은 계산 실패" 라는 결과로 정상 반환하도록 처리
실패한 규칙의 소스 정보와 추적 데이터가 결과에 함께 보존되도록 개선

2. YoY 증감 방향 설정 기능 연결 (Step 12-C2-R3)
배경 ESG 지표 중 일부(탄소 배출량 등 4개 규칙)는 "전년 대비 감소"가 긍정적인 의미입니다. DB에 이미 방향 설정(yoy_direction_code) 컬럼이 추가되어 있었지만, 코드에서 읽지 못하고 있었습니다.


<html>
<body>
<!--StartFragment-->
문제 | 해결
-- | --
DB에서 방향 설정값을 가져오지 않음 | DB 조회 쿼리 6개 전체에 yoy_direction_code 컬럼 추가
계산 엔진이 항상 현재 - 이전으로만 계산 | PRIOR_MINUS_CURRENT 설정 시 이전 - 현재로 계산하도록 변경
방향 정보가 결과에 없어 디버깅 어려움 | 계산 결과에 방향 코드, 현재값, 이전값, 차이값 포함

<!--EndFragment-->
</body>
</html>