### PR TITLE
fix: serialize Decimal rollup result trace payloads #156

### DIFF
--- a/backend/src/utils/rollupbatchrepository.py
+++ b/backend/src/utils/rollupbatchrepository.py
@@ -1,9 +1,18 @@
 ﻿import json
-from typing import Optional
+from decimal import Decimal
+from typing import Any, Optional
 from src.utils.db import findAll, findOne
 
 BATCH_STATUS_PENDING = "pending"
 BATCH_STATUS_COMPLETED = "completed"
+
+def _jsonDefault(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        return format(value, "f")
+    raise TypeError(f"Object of type {value.__class__.__name__} is not JSON serializable")
+
+def _jsonDumps(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, default=_jsonDefault)
 
 def getActiveBatch(runId: Optional[int], sourceCycleId: Optional[int], rollupPurposeCode: str, metricScopeCode: str) -> dict:
     sql = """
@@ -404,16 +413,16 @@ def resultParams(
         int(batch["reporting_year"]),
         int(batch["parent_company_id"]),
         "CONSOLIDATED",
-        json.dumps(includedCompanyIds),
+        _jsonDumps(includedCompanyIds),
         groupMetricId,
         result["groupAtomicMetricId"],
         result.get("groupAtomicName") or result["groupAtomicMetricId"],
         result.get("valueNumeric"),
         result.get("valueText"),
         result.get("unit") or "KRW",
-        json.dumps(result.get("sourceCompanyValues") or {}),
+        _jsonDumps(result.get("sourceCompanyValues") or {}),
         result.get("formulaType"),
-        json.dumps(result.get("calculationTrace") or {}),
+        _jsonDumps(result.get("calculationTrace") or {}),
         actorUserId,
     )
     return baseParams

--- a/backend/tests/test_rollupbatchrepository.py
+++ b/backend/tests/test_rollupbatchrepository.py
@@ -1,0 +1,83 @@
+import json
+import unittest
+from decimal import Decimal
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.utils import rollupbatchrepository as repository
+
+
+class UnsupportedObject:
+    pass
+
+
+class RollupBatchRepositoryJsonTest(unittest.TestCase):
+    def test_json_dumps_serializes_nested_decimal_as_precise_string(self):
+        payload = {
+            "sourceCompanyValues": {
+                "6": Decimal("123.456789"),
+                "7": [Decimal("0.000001"), {"value": Decimal("999999999999999999.123456")}],
+            }
+        }
+
+        parsed = json.loads(repository._jsonDumps(payload))
+
+        self.assertEqual(parsed["sourceCompanyValues"]["6"], "123.456789")
+        self.assertEqual(parsed["sourceCompanyValues"]["7"][0], "0.000001")
+        self.assertEqual(parsed["sourceCompanyValues"]["7"][1]["value"], "999999999999999999.123456")
+
+    def test_json_dumps_preserves_builtin_json_types(self):
+        payload = {
+            "int": 1,
+            "str": "value",
+            "list": [1, "two", True],
+            "dict": {"nested": None},
+        }
+
+        self.assertEqual(json.loads(repository._jsonDumps(payload)), payload)
+
+    def test_json_dumps_rejects_unsupported_object(self):
+        with self.assertRaises(TypeError):
+            repository._jsonDumps({"bad": UnsupportedObject()})
+
+    def test_result_params_serializes_decimal_trace_payloads(self):
+        batch = {
+            "id": 10,
+            "reporting_year": 2024,
+            "parent_company_id": 6,
+        }
+        result = {
+            "groupMetricId": "M1",
+            "groupAtomicMetricId": "M1__G0001",
+            "groupAtomicName": "Group Atomic",
+            "valueNumeric": Decimal("123.456789"),
+            "valueText": None,
+            "unit": "KRW",
+            "formulaType": "ROLLUP_SUM",
+            "sourceCompanyValues": {
+                "M1__Q0001": {
+                    "6": Decimal("123.456789"),
+                    "7": Decimal("0.000001"),
+                }
+            },
+            "calculationTrace": {
+                "value": Decimal("999999999999999999.123456"),
+                "steps": [{"ratio": Decimal("0.000001")}],
+            },
+        }
+
+        params = repository.resultParams(batch, result, [6, 7], actorUserId=99)
+
+        self.assertEqual(json.loads(params[5]), [6, 7])
+        sourceCompanyValues = json.loads(params[12])
+        calculationTrace = json.loads(params[14])
+        self.assertEqual(sourceCompanyValues["M1__Q0001"]["6"], "123.456789")
+        self.assertEqual(sourceCompanyValues["M1__Q0001"]["7"], "0.000001")
+        self.assertEqual(calculationTrace["value"], "999999999999999999.123456")
+        self.assertEqual(calculationTrace["steps"][0]["ratio"], "0.000001")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## #️⃣연관된 이슈

#156

## 📝작업 내용

> REPORT_DISCLOSURE Rollup batch 계산 결과를 `ESG_GROUP_ROLLUP_RESULT`에 저장하는 과정에서 발생한 `Decimal` JSON 직렬화 오류를 수정했습니다.
- TypeError: Object of type Decimal is not JSON serializable

**수정 사항**
Decimal 전용 _jsonDefault() helper 추가
_jsonDumps() helper 추가
Decimal 값을 format(value, "f") 기반 문자열로 변환하여 정밀도 보존
예상하지 못한 비직렬화 객체는 기존과 동일하게 TypeError 발생
default=str 및 float() 변환은 사용하지 않음
resultParams()의 아래 payload에 _jsonDumps() 적용
includedCompanyIds
sourceCompanyValues
calculationTrace
테스트 추가

**backend/tests/test_rollupbatchrepository.py를 추가했습니다.**

검증 범위:

- nested Decimal 직렬화
- 고정소수점 정밀도 보존
- 기본 JSON 타입 유지
- 미지원 객체의 TypeError 유지
- resultParams()에서 Decimal 포함 payload 처리