### PR TITLE
Rollup 화면 구조를 유지하면서 검증 완료된 Redux thunk를 실제 화면에 연결 #156

### DIFF
--- a/backend/src/apis/rollup.py
+++ b/backend/src/apis/rollup.py
@@ -7,6 +7,7 @@ from src.utils.auth import get_token
 from src.models.rollup import (
     RollupBatchRequestDto,
     RollupBatchResponseDto,
+    RollupActiveBatchResponseDto,
     RollupBatchSourceListResponseDto,
     RollupBatchSummaryResponseDto,
     RollupCalculateResponseDto,
@@ -19,6 +20,7 @@ from src.models.rollup import (
 from src.services.rollups.service import (
     RollupError,
     calcBatch,
+    getActiveBatchStatus,
     getRequestDetail,
     getScopePreview,
     getStatus,
@@ -95,6 +97,28 @@ async def saveBatchRoute(
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@_actionRouter.get(
+    "/batches/active",
+    response_model=RollupActiveBatchResponseDto,
+    summary="Get active rollup batch status",
+)
+async def getActiveBatchRoute(
+    runId: Optional[int] = Query(None),
+    sourceCycleId: Optional[int] = Query(None),
+    rollupPurposeCode: str = Query("DMA_PRECHECK"),
+    metricScopeCode: str = Query("G0_02_FINANCIAL_BASIS"),
+    userModel=Depends(get_token),
+):
+    try:
+        return getActiveBatchStatus(runId, sourceCycleId, rollupPurposeCode, metricScopeCode, userModel)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    except RollupError as e:
+        return buildErrorResponse(e)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
 @_actionRouter.post(
     "/batches/{batchId}/calculate",
     response_model=RollupCalculateResponseDto,
@@ -121,10 +145,11 @@ async def listRequestsRoute(
     metricScopeCode: Optional[str] = Query("G0_02_FINANCIAL_BASIS"),
     includeSentYn: bool = Query(True),
     transferStatus: Optional[str] = Query(None),
+    allPurposesYn: bool = Query(False),
     userModel=Depends(get_token)
 ):
     try:
-        return listRequestsForSource(rollupPurposeCode, metricScopeCode, includeSentYn, transferStatus, userModel)
+        return listRequestsForSource(rollupPurposeCode, metricScopeCode, includeSentYn, transferStatus, allPurposesYn, userModel)
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e))
     except RollupError as e:

--- a/backend/src/models/rollup.py
+++ b/backend/src/models/rollup.py
@@ -59,6 +59,11 @@ class RollupBatchResponseDto(RollupBaseModel):
     data: RollupBatchStatusDto
 
 
+class RollupActiveBatchResponseDto(RollupBaseModel):
+    success: bool = True
+    data: Optional[RollupBatchStatusDto] = None
+
+
 class RollupResultDto(RollupBaseModel):
     groupAtomicMetricId: str
     sourceAtomicMetricIds: list[str]

--- a/backend/src/services/rollups/service.py
+++ b/backend/src/services/rollups/service.py
@@ -1,9 +1,10 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Optional
 import json
 
 from src.models.rollup import (
+    RollupActiveBatchResponseDto,
     RollupBatchRequestDto,
     RollupBatchResponseDto,
     RollupBatchSourceItemDto,
@@ -412,6 +413,7 @@ def listRequests(rollupPurposeCode: str, metricScopeCode: str, userModel) -> Rol
         metricScopeCode=metricScopeCode,
         includeSentYn=True,
         transferStatus=None,
+        allPurposesYn=False,
         userModel=userModel,
     )
 
@@ -420,16 +422,20 @@ def listRequestsForSource(
     metricScopeCode: str,
     includeSentYn: bool,
     transferStatus: Optional[str],
+    allPurposesYn: bool,
     userModel,
 ) -> RollupRequestResponseDto:
     rollupRepository = loadRepository()
-    purposeCode, scopeCode = validatePurposeScope(
-        rollupPurposeCode,
-        metricScopeCode,
-        runId=None,
-        sourceCycleId=None,
-        requireContext=False,
-    )
+    if allPurposesYn:
+        purposeCode, scopeCode = None, None
+    else:
+        purposeCode, scopeCode = validatePurposeScope(
+            rollupPurposeCode,
+            metricScopeCode,
+            runId=None,
+            sourceCycleId=None,
+            requireContext=False,
+        )
     sourceCompanyId = getSource(userModel)
     requests = rollupRepository.listRequests(
         sourceCompanyId,
@@ -654,6 +660,31 @@ def getStatus(batchId: int, userModel) -> RollupBatchSummaryResponseDto:
     if not summary:
         raise RollupError(404, "ROLLUP_BATCH_NOT_FOUND", "Rollup batch was not found.")
     return RollupBatchSummaryResponseDto(data=buildSummary(summary))
+
+def getActiveBatchStatus(
+    runId: Optional[int],
+    sourceCycleId: Optional[int],
+    rollupPurposeCode: str,
+    metricScopeCode: str,
+    userModel,
+) -> RollupActiveBatchResponseDto:
+    rollupRepository = loadRepository()
+    purposeCode, scopeCode = validatePurposeScope(
+        rollupPurposeCode,
+        metricScopeCode,
+        runId,
+        sourceCycleId,
+    )
+    context = resolveBatchContext(rollupRepository, purposeCode, runId, sourceCycleId)
+    parentCompanyId = context["parentCompanyId"]
+    checkScope(parentCompanyId, userModel)
+    
+    batch = rollupRepository.getActiveBatch(runId, sourceCycleId, purposeCode, scopeCode)
+    if not batch:
+        return RollupActiveBatchResponseDto(data=None)
+        
+    includedCompanyIds = rollupRepository.listSourceCompanyIds(int(batch["id"]))
+    return RollupActiveBatchResponseDto(data=buildBatchStatus(batch, includedCompanyIds))
 
 def resolvePreviewMetricIds(rollupRepository, purposeCode: str, parentCompanyId: int, sourceCycleId: Optional[int]) -> list[str]:
     if purposeCode == rollupRepository.ROLLUP_PURPOSE_DMA_PRECHECK:
@@ -981,5 +1012,6 @@ __all__ = [
     "listBatchSources",
     "sendSource",
     "getStatus",
+    "getActiveBatchStatus",
     "RollupError",
 ]

--- a/backend/src/utils/rollupbatchrepository.py
+++ b/backend/src/utils/rollupbatchrepository.py
@@ -47,14 +47,24 @@ def getBatch(batchId: int) -> dict:
 
 def listRequests(
     sourceCompanyId: int,
-    rollupPurposeCode: str,
-    metricScopeCode: str,
+    rollupPurposeCode: Optional[str],
+    metricScopeCode: Optional[str],
     includeSentYn: bool = True,
     transferStatus: Optional[str] = None,
 ) -> list[dict]:
     transferFilter = ""
     requestFilter = ""
-    params = [sourceCompanyId, rollupPurposeCode, metricScopeCode]
+    purposeFilter = ""
+    scopeFilter = ""
+    params = [sourceCompanyId]
+    
+    if rollupPurposeCode is not None:
+        purposeFilter = "AND b.rollup_purpose_code = ?"
+        params.append(rollupPurposeCode)
+        
+    if metricScopeCode is not None:
+        scopeFilter = "AND b.metric_scope_code = ?"
+        params.append(metricScopeCode)
     normalizedTransferStatus = str(transferStatus or "").strip().lower()
     if normalizedTransferStatus:
         transferFilter = "AND LOWER(COALESCE(s.transfer_status, '')) = ?"
@@ -88,8 +98,8 @@ def listRequests(
         WHERE s.source_company_id = ?
           AND s.source_company_id <> s.parent_company_id
           AND s.delete_yn = 0
-          AND b.rollup_purpose_code = ?
-          AND b.metric_scope_code = ?
+          {purposeFilter}
+          {scopeFilter}
           {requestFilter}
           {transferFilter}
           AND LOWER(COALESCE(b.batch_status, '')) NOT IN (
@@ -99,7 +109,7 @@ def listRequests(
               'archived'
           )
         ORDER BY s.updated_at DESC, s.id DESC
-    """.format(requestFilter=requestFilter, transferFilter=transferFilter)
+    """.format(purposeFilter=purposeFilter, scopeFilter=scopeFilter, requestFilter=requestFilter, transferFilter=transferFilter)
     return findAll(sql, tuple(params)) or []
 
 def getSource(batchId: int, sourceCompanyId: int) -> dict:

--- a/backend/tests/test_rollupreadapi.py
+++ b/backend/tests/test_rollupreadapi.py
@@ -136,6 +136,7 @@ class RollupReadApiServiceTest(unittest.TestCase):
                 "SELECTED_DISCLOSURE",
                 includeSentYn=True,
                 transferStatus="sent",
+                allPurposesYn=False,
                 userModel={},
             )
 

--- a/frontend/src/homes/onboards/OnBoard.jsx
+++ b/frontend/src/homes/onboards/OnBoard.jsx
@@ -37,6 +37,10 @@ import {
   fetchCurrentWorkflow,
   fetchOnboardingMetrics,
   fetchRollupRequests,
+  fetchActiveRollupBatch,
+  fetchRollupBatchStatus,
+  fetchRollupBatchSources,
+  initializePostDmaDisclosureScope,
   resetReportState,
   saveOnboardingMetric,
   setActiveBatchId,
@@ -575,13 +579,54 @@ const OnBoard = () => {
         return;
       }
 
-      if (nextWorkflow?.reportBasisType === "CONSOLIDATED") {
-        await dispatch(fetchRollupRequests()).unwrap();
+      const nextCycleType = resolveOnboardingCycleType(nextWorkflow, cycleTypeQuery);
+      const runId = nextWorkflow.runId;
+      let sourceCycleId;
+
+      if (nextCycleType === "POST_DMA_DISCLOSURE") {
+        const initializedRes = await dispatch(
+          initializePostDmaDisclosureScope({ runId })
+        ).unwrap();
+
+        const initializedScope = initializedRes?.data || initializedRes;
+        sourceCycleId = initializedScope?.cycleId;
       }
 
-      const nextCycleType = resolveOnboardingCycleType(nextWorkflow, cycleTypeQuery);
+      if (nextWorkflow?.reportBasisType === "CONSOLIDATED") {
+        const activeRes = await dispatch(
+          fetchActiveRollupBatch({
+            runId,
+            sourceCycleId,
+            rollupPurposeCode:
+              nextCycleType === "POST_DMA_DISCLOSURE"
+                ? "REPORT_DISCLOSURE"
+                : "DMA_PRECHECK",
+            metricScopeCode:
+              nextCycleType === "POST_DMA_DISCLOSURE"
+                ? "SELECTED_DISCLOSURE"
+                : "G0_02_FINANCIAL_BASIS",
+          })
+        ).unwrap();
+
+        const activeData = activeRes?.data || activeRes;
+
+        if (activeData?.batchId) {
+          await dispatch(
+            fetchRollupBatchStatus({ batchId: activeData.batchId })
+          ).unwrap();
+
+          await dispatch(
+            fetchRollupBatchSources({ batchId: activeData.batchId })
+          ).unwrap();
+        }
+      }
+
+      await dispatch(fetchRollupRequests({ includeSentYn: true, allPurposesYn: true })).unwrap();
+
+      const metricId = new URLSearchParams(location.search).get("metricId");
+      
       await dispatch(
-        fetchOnboardingMetrics({ companyId, reportingYear, cycleType: nextCycleType })
+        fetchOnboardingMetrics({ companyId, reportingYear, cycleType: nextCycleType, metricId })
       ).unwrap();
       await dispatch(
         fetchOnboardingAssignments({ companyId, reportingYear, cycleType: nextCycleType })
@@ -589,7 +634,7 @@ const OnBoard = () => {
     } catch (error) {
       console.error(error);
     }
-  }, [companyId, cycleTypeQuery, dispatch, reportingYear]);
+  }, [companyId, cycleTypeQuery, dispatch, reportingYear, location.search]);
 
   useEffect(() => {
     dispatch(resetReportState());

--- a/frontend/src/homes/onboards/modal/SubsidiaryTransferModal.jsx
+++ b/frontend/src/homes/onboards/modal/SubsidiaryTransferModal.jsx
@@ -37,7 +37,7 @@ const SubsidiaryTransferModal = ({ isOpen, onClose, onTransferred }) => {
   const loadRequests = async () => {
     setError(null);
     try {
-      await dispatch(fetchRollupRequests()).unwrap();
+      await dispatch(fetchRollupRequests({ allPurposesYn: true })).unwrap();
     } catch (err) {
       console.error(err);
       setError(err?.message || "요청 목록 조회에 실패했습니다.");

--- a/frontend/src/stores/reportSlice.js
+++ b/frontend/src/stores/reportSlice.js
@@ -31,6 +31,10 @@ const toApiError = (res, fallbackMessage) => ({
   error: res?.error || null,
 });
 
+const ROLLUP_API_ROOT = "/api/v1/rollups";
+const ONBOARDING_APPROVAL_API_ROOT = "/api/v1/onboarding-approvals";
+const REPORT_WORKFLOW_API_ROOT = "/api/v1/report-workflow";
+
 const rejectIfFailed = (res, rejectWithValue, fallbackMessage) => {
   if (isApiFailed(res)) {
     return rejectWithValue(toApiError(res, fallbackMessage));
@@ -60,6 +64,7 @@ const initialState = {
   workflow: {
     current: null,
     g0Status: null,
+    postDmaScope: null,
   },
 
   onboarding: {
@@ -107,6 +112,8 @@ const initialState = {
     onboardingApprovalReview: false,
     onboardingApprovalApprove: false,
     onboardingApprovalReject: false,
+    initializePostDmaDisclosureScope: false,
+    fetchActiveRollupBatch: false,
   },
 
   error: {
@@ -131,6 +138,8 @@ const initialState = {
     onboardingApprovalReview: null,
     onboardingApprovalApprove: null,
     onboardingApprovalReject: null,
+    initializePostDmaDisclosureScope: null,
+    fetchActiveRollupBatch: null,
   },
 };
 
@@ -349,7 +358,7 @@ export const fetchApprovalItems = createAsyncThunk(
     };
     if (status) params.status = status;
     try {
-      const res = await GET("/v1/onboarding-approvals", params);
+      const res = await GET(`${ONBOARDING_APPROVAL_API_ROOT}`, params);
       return rejectIfFailed(res, rejectWithValue, "승인 작업함 조회에 실패했습니다.");
     } catch (error) {
       console.error(error);
@@ -386,7 +395,7 @@ export const fetchRollupSubsidiaries = createAsyncThunk(
     if (rollupPurposeCode) params.rollupPurposeCode = rollupPurposeCode;
     if (metricScopeCode) params.metricScopeCode = metricScopeCode;
     try {
-      const res = await GET("/v1/rollups/subsidiaries", params);
+      const res = await GET(`${ROLLUP_API_ROOT}/subsidiaries`, params);
       return rejectIfFailed(res, rejectWithValue, "자회사 목록 조회에 실패했습니다.");
     } catch (error) {
       console.error(error);
@@ -402,7 +411,7 @@ export const fetchRollupScopePreview = createAsyncThunk(
   "report/fetchRollupScopePreview",
   async (payload = {}, { rejectWithValue }) => {
     try {
-      const res = await GET("/v1/rollups/scope-preview", payload);
+      const res = await GET(`${ROLLUP_API_ROOT}/scope-preview`, payload);
       return rejectIfFailed(res, rejectWithValue, "롤업 범위 미리보기 조회에 실패했습니다.");
     } catch (error) {
       console.error(error);
@@ -418,7 +427,7 @@ export const createRollupBatch = createAsyncThunk(
   "report/createRollupBatch",
   async (payload, { rejectWithValue }) => {
     try {
-      const res = await POST("/v1/rollups/batches", payload);
+      const res = await POST(`${ROLLUP_API_ROOT}/batches`, payload);
       return rejectIfFailed(res, rejectWithValue, "자회사 데이터 요청에 실패했습니다.");
     } catch (error) {
       console.error(error);
@@ -430,11 +439,47 @@ export const createRollupBatch = createAsyncThunk(
   }
 );
 
+export const fetchActiveRollupBatch = createAsyncThunk(
+  "report/fetchActiveRollupBatch",
+  async (payload, { rejectWithValue }) => {
+    try {
+      const res = await GET(`${ROLLUP_API_ROOT}/batches/active`, payload);
+      return rejectIfFailed(res, rejectWithValue, "진행 중인 롤업 배치 조회에 실패했습니다.");
+    } catch (error) {
+      console.error(error);
+      return rejectWithValue({
+        status: false,
+        message:
+          error?.message ||
+          "진행 중인 롤업 배치 조회 중 오류가 발생했습니다.",
+      });
+    }
+  }
+);
+
+export const initializePostDmaDisclosureScope = createAsyncThunk(
+  "report/initializePostDmaDisclosureScope",
+  async ({ runId }, { rejectWithValue }) => {
+    try {
+      const res = await POST(`${REPORT_WORKFLOW_API_ROOT}/${runId}/post-dma-scope/initialize`);
+      return rejectIfFailed(res, rejectWithValue, "POST DMA 스코프 초기화에 실패했습니다.");
+    } catch (error) {
+      console.error(error);
+      return rejectWithValue({
+        status: false,
+        message:
+          error?.message ||
+          "POST DMA 스코프 초기화 중 오류가 발생했습니다.",
+      });
+    }
+  }
+);
+
 export const fetchRollupRequests = createAsyncThunk(
   "report/fetchRollupRequests",
   async (payload = {}, { rejectWithValue }) => {
     try {
-      const res = await GET("/v1/rollups/requests", payload);
+      const res = await GET(`${ROLLUP_API_ROOT}/requests`, payload);
       return rejectIfFailed(res, rejectWithValue, "자회사 요청 목록 조회에 실패했습니다.");
     } catch (error) {
       console.error(error);
@@ -450,7 +495,7 @@ export const fetchRollupRequestDetail = createAsyncThunk(
   "report/fetchRollupRequestDetail",
   async ({ batchId }, { rejectWithValue }) => {
     try {
-      const res = await GET(`/v1/rollups/requests/${batchId}`);
+      const res = await GET(`${ROLLUP_API_ROOT}/requests/${batchId}`);
       return rejectIfFailed(res, rejectWithValue, "롤업 요청 상세 조회에 실패했습니다.");
     } catch (error) {
       console.error(error);
@@ -466,7 +511,7 @@ export const fetchRollupBatchSources = createAsyncThunk(
   "report/fetchRollupBatchSources",
   async ({ batchId }, { rejectWithValue }) => {
     try {
-      const res = await GET(`/v1/rollups/batches/${batchId}/sources`);
+      const res = await GET(`${ROLLUP_API_ROOT}/batches/${batchId}/sources`);
       return rejectIfFailed(res, rejectWithValue, "롤업 배치 자회사 목록 조회에 실패했습니다.");
     } catch (error) {
       console.error(error);
@@ -482,7 +527,7 @@ export const sendRollupSource = createAsyncThunk(
   "report/sendRollupSource",
   async ({ batchId }, { rejectWithValue }) => {
     try {
-      const res = await POST(`/v1/rollups/batches/${batchId}/sources/send`);
+      const res = await POST(`${ROLLUP_API_ROOT}/batches/${batchId}/sources/send`);
       return rejectIfFailed(res, rejectWithValue, "자회사 데이터 전송에 실패했습니다.");
     } catch (error) {
       console.error(error);
@@ -498,7 +543,7 @@ export const fetchRollupBatchStatus = createAsyncThunk(
   "report/fetchRollupBatchStatus",
   async ({ batchId }, { rejectWithValue }) => {
     try {
-      const res = await GET(`/v1/rollups/batches/${batchId}/status`);
+      const res = await GET(`${ROLLUP_API_ROOT}/batches/${batchId}/status`);
       return rejectIfFailed(res, rejectWithValue, "롤업 배치 상태 조회에 실패했습니다.");
     } catch (error) {
       console.error(error);
@@ -514,7 +559,7 @@ export const calculateRollupBatch = createAsyncThunk(
   "report/calculateRollupBatch",
   async ({ batchId }, { rejectWithValue }) => {
     try {
-      const res = await POST(`/v1/rollups/batches/${batchId}/calculate`);
+      const res = await POST(`${ROLLUP_API_ROOT}/batches/${batchId}/calculate`);
       return rejectIfFailed(res, rejectWithValue, "롤업 계산에 실패했습니다.");
     } catch (error) {
       console.error(error);
@@ -530,7 +575,7 @@ export const submitOnboardingApproval = createAsyncThunk(
   "report/submitOnboardingApproval",
   async (payload, { rejectWithValue }) => {
     try {
-      const res = await POST("/v1/onboarding-approvals/submit", payload);
+      const res = await POST(`${ONBOARDING_APPROVAL_API_ROOT}/submit`, payload);
       return rejectIfFailed(res, rejectWithValue, "온보딩 승인 요청에 실패했습니다.");
     } catch (error) {
       console.error(error);
@@ -547,7 +592,7 @@ export const reviewOnboardingApproval = createAsyncThunk(
   async (payload, { rejectWithValue }) => {
     try {
       const res = await POST(
-        "/v1/onboarding-approvals/review",
+        `${ONBOARDING_APPROVAL_API_ROOT}/review`,
         normalizeApprovalDecisionPayload(payload)
       );
       return rejectIfFailed(res, rejectWithValue, "온보딩 승인 검토에 실패했습니다.");
@@ -566,7 +611,7 @@ export const approveOnboardingApproval = createAsyncThunk(
   async (payload, { rejectWithValue }) => {
     try {
       const res = await POST(
-        "/v1/onboarding-approvals/approve",
+        `${ONBOARDING_APPROVAL_API_ROOT}/approve`,
         normalizeApprovalDecisionPayload(payload)
       );
       return rejectIfFailed(res, rejectWithValue, "온보딩 승인 처리에 실패했습니다.");
@@ -585,7 +630,7 @@ export const rejectOnboardingApproval = createAsyncThunk(
   async (payload, { rejectWithValue }) => {
     try {
       const res = await POST(
-        "/v1/onboarding-approvals/reject",
+        `${ONBOARDING_APPROVAL_API_ROOT}/reject`,
         normalizeApprovalDecisionPayload(payload)
       );
       return rejectIfFailed(res, rejectWithValue, "온보딩 승인 반려에 실패했습니다.");
@@ -796,6 +841,43 @@ const reportSlice = createSlice({
       .addCase(createRollupBatch.rejected, (state, action) => setRejected(state, "createBatch", action));
 
     builder
+      // initializePostDmaDisclosureScope
+      .addCase(initializePostDmaDisclosureScope.pending, (state) =>
+        setPending(state, "initializePostDmaDisclosureScope")
+      )
+      .addCase(initializePostDmaDisclosureScope.fulfilled, (state, action) => {
+        state.loading.initializePostDmaDisclosureScope = false;
+        state.error.initializePostDmaDisclosureScope = null;
+        state.workflow.postDmaScope = dataOf(action.payload);
+      })
+      .addCase(initializePostDmaDisclosureScope.rejected, (state, action) => {
+        setRejected(state, "initializePostDmaDisclosureScope", action);
+        state.workflow.postDmaScope = null;
+      })
+
+      // fetchActiveRollupBatch
+      .addCase(fetchActiveRollupBatch.pending, (state) =>
+        setPending(state, "fetchActiveRollupBatch")
+      )
+      .addCase(fetchActiveRollupBatch.fulfilled, (state, action) => {
+        state.loading.fetchActiveRollupBatch = false;
+        state.error.fetchActiveRollupBatch = null;
+
+        const hasDataField =
+          action.payload &&
+          Object.prototype.hasOwnProperty.call(action.payload, "data");
+
+        const data = hasDataField
+          ? action.payload.data
+          : action.payload;
+
+        state.rollup.activeBatchId = data?.batchId ?? null;
+        state.rollup.batchStatus = data || null;
+      })
+      .addCase(fetchActiveRollupBatch.rejected, (state, action) => {
+        setRejected(state, "fetchActiveRollupBatch", action);
+      })
+
       .addCase(fetchRollupRequests.pending, (state) => setPending(state, "requests"))
       .addCase(fetchRollupRequests.fulfilled, (state, action) => {
         state.loading.requests = false;

--- a/frontend/src/stores/reportSlice.js
+++ b/frontend/src/stores/reportSlice.js
@@ -1,4 +1,4 @@
-import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+﻿import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import { GET, POST, PATCH } from "@utils/Network";
 
 export const DEFAULT_REPORTING_YEAR = new Date().getFullYear();
@@ -40,6 +40,15 @@ const rejectIfFailed = (res, rejectWithValue, fallbackMessage) => {
 
 const dataOf = (payload) => payload?.data ?? payload;
 
+const normalizeApprovalDecisionPayload = (payload = {}) => {
+  const normalized = { ...payload };
+  if (normalized.commentText == null && normalized.comment != null) {
+    normalized.commentText = normalized.comment;
+  }
+  delete normalized.comment;
+  return normalized;
+};
+
 const itemsOf = (payload) => {
   const data = dataOf(payload);
   if (Array.isArray(data?.items)) return data.items;
@@ -62,11 +71,16 @@ const initialState = {
     projects: [],
     selectedProject: null,
     items: [],
+    lastMutationResult: null,
+    lastMutationError: null,
   },
 
   rollup: {
     subsidiaries: [],
+    scopePreview: null,
     requests: [],
+    selectedRequestDetail: null,
+    batchSources: [],
     activeBatchId: null,
     batchStatus: null,
   },
@@ -81,11 +95,18 @@ const initialState = {
     approvalProjects: false,
     approvals: false,
     subsidiaries: false,
+    rollupScopePreview: false,
     createBatch: false,
     requests: false,
+    rollupRequestDetail: false,
+    rollupBatchSources: false,
     sendSource: false,
     batchStatus: false,
     calculateBatch: false,
+    onboardingApprovalSubmit: false,
+    onboardingApprovalReview: false,
+    onboardingApprovalApprove: false,
+    onboardingApprovalReject: false,
   },
 
   error: {
@@ -98,11 +119,18 @@ const initialState = {
     approvalProjects: null,
     approvals: null,
     subsidiaries: null,
+    rollupScopePreview: null,
     createBatch: null,
     requests: null,
+    rollupRequestDetail: null,
+    rollupBatchSources: null,
     sendSource: null,
     batchStatus: null,
     calculateBatch: null,
+    onboardingApprovalSubmit: null,
+    onboardingApprovalReview: null,
+    onboardingApprovalApprove: null,
+    onboardingApprovalReject: null,
   },
 };
 
@@ -321,7 +349,7 @@ export const fetchApprovalItems = createAsyncThunk(
     };
     if (status) params.status = status;
     try {
-      const res = await GET("/onboardingApproval", params);
+      const res = await GET("/v1/onboarding-approvals", params);
       return rejectIfFailed(res, rejectWithValue, "승인 작업함 조회에 실패했습니다.");
     } catch (error) {
       console.error(error);
@@ -351,9 +379,14 @@ export const fetchApprovalProjects = createAsyncThunk(
 
 export const fetchRollupSubsidiaries = createAsyncThunk(
   "report/fetchRollupSubsidiaries",
-  async ({ runId }, { rejectWithValue }) => {
+  async ({ runId, sourceCycleId, rollupPurposeCode, metricScopeCode } = {}, { rejectWithValue }) => {
+    const params = {};
+    if (runId != null) params.runId = runId;
+    if (sourceCycleId != null) params.sourceCycleId = sourceCycleId;
+    if (rollupPurposeCode) params.rollupPurposeCode = rollupPurposeCode;
+    if (metricScopeCode) params.metricScopeCode = metricScopeCode;
     try {
-      const res = await GET("/rollup/subsidiaries", { runId });
+      const res = await GET("/v1/rollups/subsidiaries", params);
       return rejectIfFailed(res, rejectWithValue, "자회사 목록 조회에 실패했습니다.");
     } catch (error) {
       console.error(error);
@@ -365,11 +398,27 @@ export const fetchRollupSubsidiaries = createAsyncThunk(
   }
 );
 
+export const fetchRollupScopePreview = createAsyncThunk(
+  "report/fetchRollupScopePreview",
+  async (payload = {}, { rejectWithValue }) => {
+    try {
+      const res = await GET("/v1/rollups/scope-preview", payload);
+      return rejectIfFailed(res, rejectWithValue, "롤업 범위 미리보기 조회에 실패했습니다.");
+    } catch (error) {
+      console.error(error);
+      return rejectWithValue({
+        status: false,
+        message: "롤업 범위 미리보기 조회 중 오류가 발생했습니다.",
+      });
+    }
+  }
+);
+
 export const createRollupBatch = createAsyncThunk(
   "report/createRollupBatch",
   async (payload, { rejectWithValue }) => {
     try {
-      const res = await POST("/rollup/batches", payload);
+      const res = await POST("/v1/rollups/batches", payload);
       return rejectIfFailed(res, rejectWithValue, "자회사 데이터 요청에 실패했습니다.");
     } catch (error) {
       console.error(error);
@@ -383,9 +432,9 @@ export const createRollupBatch = createAsyncThunk(
 
 export const fetchRollupRequests = createAsyncThunk(
   "report/fetchRollupRequests",
-  async (_, { rejectWithValue }) => {
+  async (payload = {}, { rejectWithValue }) => {
     try {
-      const res = await GET("/rollup/requests");
+      const res = await GET("/v1/rollups/requests", payload);
       return rejectIfFailed(res, rejectWithValue, "자회사 요청 목록 조회에 실패했습니다.");
     } catch (error) {
       console.error(error);
@@ -397,11 +446,43 @@ export const fetchRollupRequests = createAsyncThunk(
   }
 );
 
+export const fetchRollupRequestDetail = createAsyncThunk(
+  "report/fetchRollupRequestDetail",
+  async ({ batchId }, { rejectWithValue }) => {
+    try {
+      const res = await GET(`/v1/rollups/requests/${batchId}`);
+      return rejectIfFailed(res, rejectWithValue, "롤업 요청 상세 조회에 실패했습니다.");
+    } catch (error) {
+      console.error(error);
+      return rejectWithValue({
+        status: false,
+        message: "롤업 요청 상세 조회 중 오류가 발생했습니다.",
+      });
+    }
+  }
+);
+
+export const fetchRollupBatchSources = createAsyncThunk(
+  "report/fetchRollupBatchSources",
+  async ({ batchId }, { rejectWithValue }) => {
+    try {
+      const res = await GET(`/v1/rollups/batches/${batchId}/sources`);
+      return rejectIfFailed(res, rejectWithValue, "롤업 배치 자회사 목록 조회에 실패했습니다.");
+    } catch (error) {
+      console.error(error);
+      return rejectWithValue({
+        status: false,
+        message: "롤업 배치 자회사 목록 조회 중 오류가 발생했습니다.",
+      });
+    }
+  }
+);
+
 export const sendRollupSource = createAsyncThunk(
   "report/sendRollupSource",
   async ({ batchId }, { rejectWithValue }) => {
     try {
-      const res = await POST(`/rollup/batches/${batchId}/sources/send`);
+      const res = await POST(`/v1/rollups/batches/${batchId}/sources/send`);
       return rejectIfFailed(res, rejectWithValue, "자회사 데이터 전송에 실패했습니다.");
     } catch (error) {
       console.error(error);
@@ -417,7 +498,7 @@ export const fetchRollupBatchStatus = createAsyncThunk(
   "report/fetchRollupBatchStatus",
   async ({ batchId }, { rejectWithValue }) => {
     try {
-      const res = await GET(`/rollup/batches/${batchId}/status`);
+      const res = await GET(`/v1/rollups/batches/${batchId}/status`);
       return rejectIfFailed(res, rejectWithValue, "롤업 배치 상태 조회에 실패했습니다.");
     } catch (error) {
       console.error(error);
@@ -433,13 +514,86 @@ export const calculateRollupBatch = createAsyncThunk(
   "report/calculateRollupBatch",
   async ({ batchId }, { rejectWithValue }) => {
     try {
-      const res = await POST(`/rollup/batches/${batchId}/calculate`);
+      const res = await POST(`/v1/rollups/batches/${batchId}/calculate`);
       return rejectIfFailed(res, rejectWithValue, "롤업 계산에 실패했습니다.");
     } catch (error) {
       console.error(error);
       return rejectWithValue({
         status: false,
         message: "롤업 계산 중 오류가 발생했습니다.",
+      });
+    }
+  }
+);
+
+export const submitOnboardingApproval = createAsyncThunk(
+  "report/submitOnboardingApproval",
+  async (payload, { rejectWithValue }) => {
+    try {
+      const res = await POST("/v1/onboarding-approvals/submit", payload);
+      return rejectIfFailed(res, rejectWithValue, "온보딩 승인 요청에 실패했습니다.");
+    } catch (error) {
+      console.error(error);
+      return rejectWithValue({
+        status: false,
+        message: "온보딩 승인 요청 중 오류가 발생했습니다.",
+      });
+    }
+  }
+);
+
+export const reviewOnboardingApproval = createAsyncThunk(
+  "report/reviewOnboardingApproval",
+  async (payload, { rejectWithValue }) => {
+    try {
+      const res = await POST(
+        "/v1/onboarding-approvals/review",
+        normalizeApprovalDecisionPayload(payload)
+      );
+      return rejectIfFailed(res, rejectWithValue, "온보딩 승인 검토에 실패했습니다.");
+    } catch (error) {
+      console.error(error);
+      return rejectWithValue({
+        status: false,
+        message: "온보딩 승인 검토 중 오류가 발생했습니다.",
+      });
+    }
+  }
+);
+
+export const approveOnboardingApproval = createAsyncThunk(
+  "report/approveOnboardingApproval",
+  async (payload, { rejectWithValue }) => {
+    try {
+      const res = await POST(
+        "/v1/onboarding-approvals/approve",
+        normalizeApprovalDecisionPayload(payload)
+      );
+      return rejectIfFailed(res, rejectWithValue, "온보딩 승인 처리에 실패했습니다.");
+    } catch (error) {
+      console.error(error);
+      return rejectWithValue({
+        status: false,
+        message: "온보딩 승인 처리 중 오류가 발생했습니다.",
+      });
+    }
+  }
+);
+
+export const rejectOnboardingApproval = createAsyncThunk(
+  "report/rejectOnboardingApproval",
+  async (payload, { rejectWithValue }) => {
+    try {
+      const res = await POST(
+        "/v1/onboarding-approvals/reject",
+        normalizeApprovalDecisionPayload(payload)
+      );
+      return rejectIfFailed(res, rejectWithValue, "온보딩 승인 반려에 실패했습니다.");
+    } catch (error) {
+      console.error(error);
+      return rejectWithValue({
+        status: false,
+        message: "온보딩 승인 반려 중 오류가 발생했습니다.",
       });
     }
   }
@@ -453,6 +607,23 @@ const setPending = (state, key) => {
 const setRejected = (state, key, action) => {
   state.loading[key] = false;
   state.error[key] = action.payload || action.error || null;
+};
+
+const setApprovalMutationPending = (state, key) => {
+  setPending(state, key);
+  state.approval.lastMutationError = null;
+};
+
+const setApprovalMutationFulfilled = (state, key, action) => {
+  state.loading[key] = false;
+  state.error[key] = null;
+  state.approval.lastMutationResult = dataOf(action.payload);
+  state.approval.lastMutationError = null;
+};
+
+const setApprovalMutationRejected = (state, key, action) => {
+  setRejected(state, key, action);
+  state.approval.lastMutationError = action.payload || action.error || null;
 };
 
 const reportSlice = createSlice({
@@ -604,6 +775,18 @@ const reportSlice = createSlice({
       });
 
     builder
+      .addCase(fetchRollupScopePreview.pending, (state) => setPending(state, "rollupScopePreview"))
+      .addCase(fetchRollupScopePreview.fulfilled, (state, action) => {
+        state.loading.rollupScopePreview = false;
+        state.error.rollupScopePreview = null;
+        state.rollup.scopePreview = dataOf(action.payload);
+      })
+      .addCase(fetchRollupScopePreview.rejected, (state, action) => {
+        setRejected(state, "rollupScopePreview", action);
+        state.rollup.scopePreview = null;
+      });
+
+    builder
       .addCase(createRollupBatch.pending, (state) => setPending(state, "createBatch"))
       .addCase(createRollupBatch.fulfilled, (state, action) => {
         state.loading.createBatch = false;
@@ -622,6 +805,30 @@ const reportSlice = createSlice({
       .addCase(fetchRollupRequests.rejected, (state, action) => {
         setRejected(state, "requests", action);
         state.rollup.requests = [];
+      });
+
+    builder
+      .addCase(fetchRollupRequestDetail.pending, (state) => setPending(state, "rollupRequestDetail"))
+      .addCase(fetchRollupRequestDetail.fulfilled, (state, action) => {
+        state.loading.rollupRequestDetail = false;
+        state.error.rollupRequestDetail = null;
+        state.rollup.selectedRequestDetail = dataOf(action.payload);
+      })
+      .addCase(fetchRollupRequestDetail.rejected, (state, action) => {
+        setRejected(state, "rollupRequestDetail", action);
+        state.rollup.selectedRequestDetail = null;
+      });
+
+    builder
+      .addCase(fetchRollupBatchSources.pending, (state) => setPending(state, "rollupBatchSources"))
+      .addCase(fetchRollupBatchSources.fulfilled, (state, action) => {
+        state.loading.rollupBatchSources = false;
+        state.error.rollupBatchSources = null;
+        state.rollup.batchSources = itemsOf(action.payload);
+      })
+      .addCase(fetchRollupBatchSources.rejected, (state, action) => {
+        setRejected(state, "rollupBatchSources", action);
+        state.rollup.batchSources = [];
       });
 
     builder
@@ -652,6 +859,50 @@ const reportSlice = createSlice({
         state.rollup.batchStatus = dataOf(action.payload) || state.rollup.batchStatus;
       })
       .addCase(calculateRollupBatch.rejected, (state, action) => setRejected(state, "calculateBatch", action));
+
+    builder
+      .addCase(submitOnboardingApproval.pending, (state) =>
+        setApprovalMutationPending(state, "onboardingApprovalSubmit")
+      )
+      .addCase(submitOnboardingApproval.fulfilled, (state, action) =>
+        setApprovalMutationFulfilled(state, "onboardingApprovalSubmit", action)
+      )
+      .addCase(submitOnboardingApproval.rejected, (state, action) =>
+        setApprovalMutationRejected(state, "onboardingApprovalSubmit", action)
+      );
+
+    builder
+      .addCase(reviewOnboardingApproval.pending, (state) =>
+        setApprovalMutationPending(state, "onboardingApprovalReview")
+      )
+      .addCase(reviewOnboardingApproval.fulfilled, (state, action) =>
+        setApprovalMutationFulfilled(state, "onboardingApprovalReview", action)
+      )
+      .addCase(reviewOnboardingApproval.rejected, (state, action) =>
+        setApprovalMutationRejected(state, "onboardingApprovalReview", action)
+      );
+
+    builder
+      .addCase(approveOnboardingApproval.pending, (state) =>
+        setApprovalMutationPending(state, "onboardingApprovalApprove")
+      )
+      .addCase(approveOnboardingApproval.fulfilled, (state, action) =>
+        setApprovalMutationFulfilled(state, "onboardingApprovalApprove", action)
+      )
+      .addCase(approveOnboardingApproval.rejected, (state, action) =>
+        setApprovalMutationRejected(state, "onboardingApprovalApprove", action)
+      );
+
+    builder
+      .addCase(rejectOnboardingApproval.pending, (state) =>
+        setApprovalMutationPending(state, "onboardingApprovalReject")
+      )
+      .addCase(rejectOnboardingApproval.fulfilled, (state, action) =>
+        setApprovalMutationFulfilled(state, "onboardingApprovalReject", action)
+      )
+      .addCase(rejectOnboardingApproval.rejected, (state, action) =>
+        setApprovalMutationRejected(state, "onboardingApprovalReject", action)
+      );
   },
 });
 


### PR DESCRIPTION
## #️⃣연관된 이슈

>#156

## 📝작업 내용

수정 파일: frontend/src/stores/reportSlice.js 단 1개의 파일만 수정했습니다.

Rollup API root 상수: ROLLUP_API_ROOT = "/api/v1/rollups" 상수를 추가하고 하위 10개의 롤업 관련 경로(subsidiaries, batches, requests 등)에 모두 적용했습니다.

Approval API root 상수: ONBOARDING_APPROVAL_API_ROOT = "/api/v1/onboarding-approvals" 상수를 추가하고 submit, review, approve, reject 등 5개 승인 관련 경로에 모두 적용했습니다.

report-workflow singular path 수정: REPORT_WORKFLOW_API_ROOT = "/api/v1/report-workflow" 상수를 추가하고, 기존의 오타였던 report-workflows(복수형)를 단수형으로 완벽히 치환하여 ${REPORT_WORKFLOW_API_ROOT}/${runId}/post-dma-scope/initialize 로직에 연결했습니다.

loading / error key 추가: initialState의 loading과 error 블록에 initializePostDmaDisclosureScope와 fetchActiveRollupBatch 키를 각각 명시했습니다.

active batch reducer 연결: fetchActiveRollupBatch에 대한 extraReducers를 작성하여 fulfilled 시 state.rollup.activeBatchId = data?.batchId ?? null; 및 state.rollup.batchStatus = data || null; 로 복구하도록 연결했으며, 기존 UI 상태가 삭제되지 않게 안전히 처리했습니다.

post-DMA scope reducer 연결: initializePostDmaDisclosureScope에 대한 extraReducers를 작성하여 state.workflow.postDmaScope에 data를 주입하도록 구성했습니다.