### PR TITLE
Feature/rollup mdal ljb

### DIFF
--- a/backend/src/apis/onboardingApproval.py
+++ b/backend/src/apis/onboardingApproval.py
@@ -5,12 +5,14 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from src.models.onboarding import (
     OnboardingApprovalActionResponseDto,
     OnboardingApprovalDecisionRequestDto,
+    OnboardingApprovalDetailResponseDto,
     OnboardingApprovalListResponseDto,
     OnboardingApprovalRequestDto,
     OnboardingApprovalStatusResponseDto,
 )
 from src.services.onboardings.service import (
     approveApproval,
+    getApprovalDetail,
     getApprovalStatus,
     listApprovals,
     rejectApproval,
@@ -103,6 +105,33 @@ async def listApprovalsRoute(
 
 
 @router.get(
+    "/detail",
+    response_model=OnboardingApprovalDetailResponseDto,
+    summary="Get onboarding approval detail",
+)
+@onboardingApprovalRouter.get(
+    "/detail",
+    response_model=OnboardingApprovalDetailResponseDto,
+    summary="Get onboarding approval detail",
+)
+async def getApprovalDetailRoute(
+    companyId: int = Query(...),
+    reportingYear: int = Query(...),
+    metricId: str = Query(...),
+    cycleType: str = Query(default="PRE_DMA_G0"),
+    userModel=Depends(get_token),
+):
+    try:
+        return getApprovalDetail(companyId, reportingYear, metricId, cycleType, userModel)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get(
     "/status",
     response_model=OnboardingApprovalStatusResponseDto,
     summary="Get PRE_DMA_G0 G0-02 approval status",
@@ -116,10 +145,11 @@ async def getApprovalStatusRoute(
     companyId: int = Query(...),
     reportingYear: int = Query(...),
     metricId: str = Query(default="G0-02"),
+    cycleType: str = Query(default="PRE_DMA_G0"),
     userModel=Depends(get_token),
 ):
     try:
-        return getApprovalStatus(companyId, reportingYear, metricId, userModel)
+        return getApprovalStatus(companyId, reportingYear, metricId, userModel, cycleType)
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e))
     except ValueError as e:

--- a/backend/src/models/onboarding.py
+++ b/backend/src/models/onboarding.py
@@ -245,6 +245,29 @@ class OnboardingApprovalStatusResponseDto(BaseModel):
     data: OnboardingApprovalStatusDataDto
 
 
+class OnboardingApprovalAtomicDetailItemDto(BaseModel):
+    atomicMetricId: str
+    atomicName: Optional[str] = None
+    dataValueType: Optional[str] = None
+    atomicDataRole: Optional[str] = None
+    inputMode: Optional[str] = None
+    valueText: Optional[str] = None
+    valueNumeric: Optional[float] = None
+    unit: Optional[str] = None
+    inputStatus: Optional[str] = None
+    updatedAt: Optional[str] = None
+    evidenceCount: int = 0
+
+
+class OnboardingApprovalDetailDataDto(OnboardingApprovalStatusDataDto):
+    atomicItems: List[OnboardingApprovalAtomicDetailItemDto] = Field(default_factory=list)
+
+
+class OnboardingApprovalDetailResponseDto(BaseModel):
+    success: bool = True
+    data: OnboardingApprovalDetailDataDto
+
+
 class OnboardingApprovalActionResponseDto(BaseModel):
     success: bool = True
     data: OnboardingApprovalStatusDataDto

--- a/backend/src/services/onboardings/service.py
+++ b/backend/src/services/onboardings/service.py
@@ -4,6 +4,9 @@ from typing import Optional
 
 from src.models.onboarding import (
     OnboardingApprovalActionResponseDto,
+    OnboardingApprovalAtomicDetailItemDto,
+    OnboardingApprovalDetailDataDto,
+    OnboardingApprovalDetailResponseDto,
     OnboardingApprovalItemDto,
     OnboardingApprovalListDataDto,
     OnboardingApprovalListResponseDto,
@@ -809,6 +812,27 @@ def getApprovalStatus(
     return OnboardingApprovalStatusResponseDto(data=statusDto(summary, userModel))
 
 
+def getApprovalDetail(
+    companyId: int,
+    reportingYear: int,
+    metricId: str,
+    cycleType: str,
+    userModel,
+) -> OnboardingApprovalDetailResponseDto:
+    checkScope(companyId, userModel)
+    cycle = requireCycle(companyId, reportingYear, cycleType)
+    summary = approvalService.buildMetricApprovalSummary(companyId, reportingYear, metricId, cycleType)
+    if not checkMetricStatusPermission(summary, userModel):
+        raise PermissionError("Only approvers, reviewers, or the assigned employee can view approval status")
+    scopes = repo.listMetricScopes(int(cycle["id"]), companyId, metricId)
+    if not scopes:
+        raise ValueError("Metric is not in active cycle scope")
+    atomicRows = repo.listApprovalAtomicDetailRows(companyId, reportingYear, int(cycle["id"]), metricId)
+    return OnboardingApprovalDetailResponseDto(
+        data=detailDto(summary, atomicRows, userModel)
+    )
+
+
 def ensureWorkflowPreDmaG0Cycle(run: dict, actorUserId: Optional[int] = None) -> dict:
     if not run:
         return {}
@@ -863,6 +887,35 @@ def statusDto(summary: dict, userModel) -> OnboardingApprovalStatusDataDto:
             and promotedQuantAtomicCount > 0
             and approvedPromotedFactCount >= promotedQuantAtomicCount
         ),
+    )
+
+
+def detailDto(
+    summary: dict,
+    atomicRows: list[dict],
+    userModel,
+) -> OnboardingApprovalDetailDataDto:
+    base = statusDto(summary, userModel)
+    payload = base.model_dump() if hasattr(base, "model_dump") else base.dict()
+    return OnboardingApprovalDetailDataDto(
+        **payload,
+        atomicItems=[
+            OnboardingApprovalAtomicDetailItemDto(
+                atomicMetricId=row["atomic_metric_id"],
+                atomicName=row.get("atomic_name"),
+                dataValueType=row.get("data_value_type"),
+                atomicDataRole=row.get("atomic_data_role"),
+                inputMode=row.get("input_mode"),
+                valueText=row.get("value_text"),
+                valueNumeric=row.get("value_numeric"),
+                unit=row.get("unit"),
+                inputStatus=row.get("input_status"),
+                updatedAt=row.get("updated_at"),
+                evidenceCount=int(row.get("evidence_count") or 0),
+            )
+            for row in atomicRows
+            if row.get("atomic_metric_id")
+        ],
     )
 
 

--- a/backend/src/services/onboardings/service.py
+++ b/backend/src/services/onboardings/service.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 from typing import Optional
 
@@ -759,7 +759,7 @@ def approveApproval(request, userModel) -> OnboardingApprovalActionResponseDto:
 
 def rejectApproval(request, userModel) -> OnboardingApprovalActionResponseDto:
     checkScope(request.companyId, userModel)
-    checkApprover(userModel)
+    checkReviewer(userModel)
     commentText = (getattr(request, "commentText", None) or "").strip()
     if not commentText:
         raise ValueError("commentText is required for rejection")

--- a/backend/src/utils/onboardingapprovalrepository.py
+++ b/backend/src/utils/onboardingapprovalrepository.py
@@ -272,6 +272,51 @@ def listApprovalFactRows(companyId: int, reportingYear: int, metricIds: list[str
     ) or []
 
 
+def listApprovalAtomicDetailRows(
+    companyId: int,
+    reportingYear: int,
+    cycleId: int,
+    metricId: str,
+) -> list[dict]:
+    scopes = scopeRepo.listMetricScopes(cycleId, companyId, metricId)
+    if not scopes:
+        return []
+
+    masterRows = scopeRepo.listAtomicMaster([metricId])
+    inputRows = listApprovalInputRows(companyId, reportingYear, [metricId])
+    factRows = listApprovalFactRows(companyId, reportingYear, [metricId])
+    inputByAtomic = {row.get("atomic_metric_id"): row for row in inputRows}
+    factByAtomic = {row.get("atomic_metric_id"): row for row in factRows}
+
+    items = []
+    for master in masterRows:
+        atomicMetricId = master.get("atomic_metric_id")
+        if not atomicMetricId:
+            continue
+
+        inputRow = inputByAtomic.get(atomicMetricId) or {}
+        factRow = factByAtomic.get(atomicMetricId) or {}
+        valueRow = inputRow if inputRepo.hasMetricValue(inputRow) else factRow
+        valueNumeric = valueRow.get("value_numeric")
+
+        items.append(
+            {
+                "atomic_metric_id": atomicMetricId,
+                "atomic_name": master.get("atomic_name_kr"),
+                "data_value_type": master.get("data_value_type"),
+                "atomic_data_role": master.get("atomic_data_role"),
+                "input_mode": None,
+                "value_text": valueRow.get("value_text"),
+                "value_numeric": float(valueNumeric) if valueNumeric is not None else None,
+                "unit": valueRow.get("unit") or master.get("unit"),
+                "input_status": valueRow.get("input_status"),
+                "updated_at": inputRepo.formatDatetime(valueRow.get("updated_at")),
+                "evidence_count": 0,
+            }
+        )
+    return items
+
+
 def listLatestApprovalHistories(
     companyId: int,
     reportingYear: int,
@@ -538,6 +583,7 @@ __all__ = [
     "resolveActionSupport",
     "listApprovalInputRows",
     "listApprovalFactRows",
+    "listApprovalAtomicDetailRows",
     "listLatestApprovalHistories",
     "resolveCycleApprovalStatus",
     "listApprovalSummaries",

--- a/backend/src/utils/onboardingapprovalrepository.py
+++ b/backend/src/utils/onboardingapprovalrepository.py
@@ -290,6 +290,9 @@ def listApprovalAtomicDetailRows(
 
     items = []
     for master in masterRows:
+        if not inputRepo.truthy(master.get("onboarding_input_yn")):
+            continue
+
         atomicMetricId = master.get("atomic_metric_id")
         if not atomicMetricId:
             continue

--- a/backend/tests/test_onboardingapprovaldetail.py
+++ b/backend/tests/test_onboardingapprovaldetail.py
@@ -144,6 +144,7 @@ class OnboardingApprovalDetailRepositoryTest(unittest.TestCase):
                         "atomic_name_kr": "Energy use",
                         "data_value_type": "QUANT",
                         "atomic_data_role": "INPUT",
+                        "onboarding_input_yn": 1,
                         "unit": "kWh",
                     }
                 ],
@@ -193,6 +194,7 @@ class OnboardingApprovalDetailRepositoryTest(unittest.TestCase):
                         "atomic_name_kr": "Energy use",
                         "data_value_type": "QUANT",
                         "atomic_data_role": "INPUT",
+                        "onboarding_input_yn": 1,
                         "unit": "kWh",
                     }
                 ],
@@ -216,6 +218,39 @@ class OnboardingApprovalDetailRepositoryTest(unittest.TestCase):
 
         self.assertEqual(rows[0]["value_numeric"], 100.0)
         self.assertEqual(rows[0]["input_status"], "approved")
+
+    def test_repository_excludes_non_input_atomic_items(self):
+        with patch.object(approvalRepo.scopeRepo, "listMetricScopes", return_value=[{"metric_id": "E1-06"}]), \
+            patch.object(
+                approvalRepo.scopeRepo,
+                "listAtomicMaster",
+                return_value=[
+                    {
+                        "metric_id": "E1-06",
+                        "atomic_metric_id": "E1-06__Q0001",
+                        "onboarding_input_yn": 1,
+                        "atomic_name_kr": "Energy use",
+                        "data_value_type": "QUANT",
+                        "atomic_data_role": "INPUT",
+                        "unit": "kWh",
+                    },
+                    {
+                        "metric_id": "E1-06",
+                        "atomic_metric_id": "E1-06__G0001",
+                        "onboarding_input_yn": 0,
+                        "atomic_name_kr": "Derived use",
+                        "data_value_type": "QUANT",
+                        "atomic_data_role": "DERIVED",
+                        "unit": "kWh",
+                    }
+                ],
+            ), \
+            patch.object(approvalRepo, "listApprovalInputRows", return_value=[]), \
+            patch.object(approvalRepo, "listApprovalFactRows", return_value=[]):
+            rows = approvalRepo.listApprovalAtomicDetailRows(6, 2026, 17, "E1-06")
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["atomic_metric_id"], "E1-06__Q0001")
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_onboardingapprovaldetail.py
+++ b/backend/tests/test_onboardingapprovaldetail.py
@@ -1,0 +1,222 @@
+import asyncio
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+import sys
+
+from fastapi import HTTPException
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.apis import onboardingApproval
+from src.models.onboarding import OnboardingApprovalDetailResponseDto
+from src.services.onboardings import service
+from src.utils import onboardingapprovalrepository as approvalRepo
+
+
+SUMMARY = {
+    "companyId": 6,
+    "reportingYear": 2026,
+    "metricId": "E1-06",
+    "metricName": "Climate disclosure",
+    "cycleType": "POST_DMA_DISCLOSURE",
+    "issueDomain": "environmental",
+    "approvalStatus": "SUBMITTED",
+    "inputUserId": 18,
+    "assigneeUserId": 18,
+    "cycleId": 17,
+    "assignmentId": 42,
+    "requiredAtomicCount": 1,
+    "completedAtomicCount": 1,
+    "submittedAtomicCount": 1,
+    "approvedAtomicCount": 0,
+    "missingAtomicMetricIds": [],
+    "selfSubmittedYn": False,
+    "actionSupportedYn": True,
+}
+
+
+def detail_response():
+    return OnboardingApprovalDetailResponseDto(
+        data=service.detailDto(
+            SUMMARY,
+            [
+                {
+                    "atomic_metric_id": "E1-06__Q0001",
+                    "atomic_name": "Energy use",
+                    "data_value_type": "QUANT",
+                    "atomic_data_role": "INPUT",
+                    "value_numeric": 123.45,
+                    "unit": "kWh",
+                    "input_status": "submitted",
+                    "updated_at": "2026-06-08 10:00:00",
+                    "evidence_count": 0,
+                }
+            ],
+            {"id": 18, "role": "EMPLOYEE"},
+        )
+    )
+
+
+class OnboardingApprovalDetailRouteTest(unittest.TestCase):
+    def test_detail_route_calls_service_wrapper(self):
+        expected = detail_response()
+        with patch.object(onboardingApproval, "getApprovalDetail", return_value=expected) as mocked:
+            result = asyncio.run(
+                onboardingApproval.getApprovalDetailRoute(
+                    companyId=6,
+                    reportingYear=2026,
+                    metricId="E1-06",
+                    cycleType="POST_DMA_DISCLOSURE",
+                    userModel={"id": 18},
+                )
+            )
+
+        self.assertEqual(result, expected)
+        mocked.assert_called_once()
+
+    def test_detail_route_maps_permission_error_to_403(self):
+        with patch.object(onboardingApproval, "getApprovalDetail", side_effect=PermissionError("forbidden")):
+            with self.assertRaises(HTTPException) as context:
+                asyncio.run(
+                    onboardingApproval.getApprovalDetailRoute(
+                        companyId=6,
+                        reportingYear=2026,
+                        metricId="E1-06",
+                        userModel={"id": 18},
+                    )
+                )
+
+        self.assertEqual(context.exception.status_code, 403)
+
+
+class OnboardingApprovalDetailServiceTest(unittest.TestCase):
+    def test_service_returns_atomic_items(self):
+        with patch.object(service, "checkScope"), \
+            patch.object(service, "requireCycle", return_value={"id": 17, "cycle_type": "POST_DMA_DISCLOSURE"}), \
+            patch.object(service.approvalService, "buildMetricApprovalSummary", return_value=SUMMARY), \
+            patch.object(service, "checkMetricStatusPermission", return_value=True), \
+            patch.object(service.repo, "listMetricScopes", return_value=[{"metric_id": "E1-06"}]), \
+            patch.object(
+                service.repo,
+                "listApprovalAtomicDetailRows",
+                return_value=[
+                    {
+                        "atomic_metric_id": "E1-06__Q0001",
+                        "atomic_name": "Energy use",
+                        "data_value_type": "QUANT",
+                        "atomic_data_role": "INPUT",
+                        "value_numeric": 123.45,
+                        "unit": "kWh",
+                        "input_status": "submitted",
+                        "updated_at": "2026-06-08 10:00:00",
+                        "evidence_count": 0,
+                    }
+                ],
+            ):
+            result = service.getApprovalDetail(6, 2026, "E1-06", "POST_DMA_DISCLOSURE", {"id": 18})
+
+        self.assertEqual(result.data.metricId, "E1-06")
+        self.assertEqual(result.data.cycleType, "POST_DMA_DISCLOSURE")
+        self.assertEqual(len(result.data.atomicItems), 1)
+        self.assertEqual(result.data.atomicItems[0].atomicMetricId, "E1-06__Q0001")
+        self.assertEqual(result.data.atomicItems[0].evidenceCount, 0)
+
+    def test_service_blocks_unauthorized_user(self):
+        with patch.object(service, "checkScope"), \
+            patch.object(service, "requireCycle", return_value={"id": 17, "cycle_type": "POST_DMA_DISCLOSURE"}), \
+            patch.object(service.approvalService, "buildMetricApprovalSummary", return_value=SUMMARY), \
+            patch.object(service, "checkMetricStatusPermission", return_value=False):
+            with self.assertRaises(PermissionError):
+                service.getApprovalDetail(6, 2026, "E1-06", "POST_DMA_DISCLOSURE", {"id": 99})
+
+
+class OnboardingApprovalDetailRepositoryTest(unittest.TestCase):
+    def test_repository_prefers_input_value_over_kpi_fact(self):
+        with patch.object(approvalRepo.scopeRepo, "listMetricScopes", return_value=[{"metric_id": "E1-06"}]), \
+            patch.object(
+                approvalRepo.scopeRepo,
+                "listAtomicMaster",
+                return_value=[
+                    {
+                        "metric_id": "E1-06",
+                        "atomic_metric_id": "E1-06__Q0001",
+                        "atomic_name_kr": "Energy use",
+                        "data_value_type": "QUANT",
+                        "atomic_data_role": "INPUT",
+                        "unit": "kWh",
+                    }
+                ],
+            ), \
+            patch.object(
+                approvalRepo,
+                "listApprovalInputRows",
+                return_value=[
+                    {
+                        "atomic_metric_id": "E1-06__Q0001",
+                        "value_text": None,
+                        "value_numeric": 200,
+                        "unit": "kWh",
+                        "input_status": "submitted",
+                        "updated_at": None,
+                    }
+                ],
+            ), \
+            patch.object(
+                approvalRepo,
+                "listApprovalFactRows",
+                return_value=[
+                    {
+                        "atomic_metric_id": "E1-06__Q0001",
+                        "value_text": None,
+                        "value_numeric": 100,
+                        "unit": "kWh",
+                        "input_status": "approved",
+                        "updated_at": None,
+                    }
+                ],
+            ):
+            rows = approvalRepo.listApprovalAtomicDetailRows(6, 2026, 17, "E1-06")
+
+        self.assertEqual(rows[0]["value_numeric"], 200.0)
+        self.assertEqual(rows[0]["input_status"], "submitted")
+
+    def test_repository_falls_back_to_kpi_fact(self):
+        with patch.object(approvalRepo.scopeRepo, "listMetricScopes", return_value=[{"metric_id": "E1-06"}]), \
+            patch.object(
+                approvalRepo.scopeRepo,
+                "listAtomicMaster",
+                return_value=[
+                    {
+                        "metric_id": "E1-06",
+                        "atomic_metric_id": "E1-06__Q0001",
+                        "atomic_name_kr": "Energy use",
+                        "data_value_type": "QUANT",
+                        "atomic_data_role": "INPUT",
+                        "unit": "kWh",
+                    }
+                ],
+            ), \
+            patch.object(approvalRepo, "listApprovalInputRows", return_value=[]), \
+            patch.object(
+                approvalRepo,
+                "listApprovalFactRows",
+                return_value=[
+                    {
+                        "atomic_metric_id": "E1-06__Q0001",
+                        "value_text": None,
+                        "value_numeric": 100,
+                        "unit": "kWh",
+                        "input_status": "approved",
+                        "updated_at": None,
+                    }
+                ],
+            ):
+            rows = approvalRepo.listApprovalAtomicDetailRows(6, 2026, 17, "E1-06")
+
+        self.assertEqual(rows[0]["value_numeric"], 100.0)
+        self.assertEqual(rows[0]["input_status"], "approved")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_onboardingapprovalreview.py
+++ b/backend/tests/test_onboardingapprovalreview.py
@@ -63,5 +63,26 @@ class OnboardingApprovalReviewRouteTest(unittest.TestCase):
         self.assertEqual(context.exception.status_code, 409)
 
 
+from src.services.onboardings import service
+
+class OnboardingApprovalReviewServiceTest(unittest.TestCase):
+    def test_reject_allows_consultant_and_blocks_employee(self):
+        mock_summary = {"companyId": 6, "reportingYear": 2026, "metricId": "E1-06", "approvalStatus": "REJECTED"}
+        with patch.object(service, "checkScope"), patch.object(service.approvalService, "rejectMetricApproval", return_value=mock_summary):
+            # Consultant (reviewer) allowed
+            service.rejectApproval(request(), {"id": 1, "role": "CONSULTANT"})
+
+            # Employee blocked
+            with self.assertRaises(PermissionError):
+                service.rejectApproval(request(), {"id": 2, "role": "EMPLOYEE"})
+
+    def test_approve_blocks_consultant(self):
+        mock_summary = {"companyId": 6, "reportingYear": 2026, "metricId": "E1-06", "approvalStatus": "APPROVED"}
+        with patch.object(service, "checkScope"), patch.object(service.approvalService, "approveMetricApproval", return_value=mock_summary):
+            # Consultant (not approver) blocked
+            with self.assertRaises(PermissionError):
+                service.approveApproval(request(), {"id": 1, "role": "CONSULTANT"})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/frontend/src/homes/mains/DataTab.jsx
+++ b/frontend/src/homes/mains/DataTab.jsx
@@ -99,6 +99,11 @@ const DataTab = ({
   fetchData,
   setDataPage,
   handleAction,
+  actionLoading = false,
+  approvalDetail = null,
+  approvalDetailLoading = false,
+  approvalDetailError = null,
+  fetchApprovalDetail,
 }) => {
   const [previewRole, setPreviewRole] = useState("ESG_MANAGER");
   const [previewOnboardingScenario, setPreviewOnboardingScenario] = useState(
@@ -240,6 +245,7 @@ const DataTab = ({
 
   const canBulkApprove =
     !readOnlyYn &&
+    !actionLoading &&
     !isConsultant &&
     selectedSupportedRows.length > 0 &&
     selectedSupportedRows.every(
@@ -247,29 +253,34 @@ const DataTab = ({
     );
 
   const handleBulkReview = () => {
-    if (!selectedSupportedRows.length) return;
+    if (actionLoading || !selectedSupportedRows.length) return;
     handleBulkAction("REVIEWED");
   };
 
   const handleBulkApprove = () => {
-    if (!canBulkApprove) return;
+    if (actionLoading || !canBulkApprove) return;
     handleBulkAction("APPROVED");
   };
 
   const handleBulkReject = () => {
-    if (!selectedSupportedRows.length) return;
+    if (actionLoading || !selectedSupportedRows.length) return;
     setBulkRejectReason("");
     setIsBulkRejectModalOpen(true);
   };
 
-  const handleOpenApprovalDetail = (item, actionMode = null) => {
+  const handleOpenApprovalDetail = async (item, actionMode = null) => {
     setSelectedItemForDetail(item);
     setModalActionMode(actionMode);
     setIsDetailModalOpen(true);
+    try {
+      await fetchApprovalDetail?.(item.metricId || item.id);
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   const handleToggleSelectAll = () => {
-    if (readOnlyYn) return;
+    if (readOnlyYn || actionLoading) return;
 
     const visibleIds = visibleInputs.map((item) => item.id);
     const allSelected =
@@ -282,17 +293,30 @@ const DataTab = ({
   };
 
   const toggleSelect = (id) => {
-    if (readOnlyYn) return;
+    if (readOnlyYn || actionLoading) return;
 
     setSelectedIds((prev) =>
       prev.includes(id) ? prev.filter((value) => value !== id) : [...prev, id]
     );
   };
 
-  const runAction = (item, status, commentText = "") => {
-    if (!isActionSupported(item, readOnlyYn)) return;
-    handleAction(item.id, status, commentText);
+  const runAction = async (item, status, commentText = "") => {
+    if (!isActionSupported(item, readOnlyYn) || actionLoading) return false;
+    return handleAction(item.id, status, commentText);
   };
+
+  const closeDetailModal = () => {
+    setIsDetailModalOpen(false);
+    setModalActionMode(null);
+  };
+
+  const detailMetricItem =
+    approvalDetail?.metricId === selectedItemForDetail?.metricId
+      ? {
+          ...selectedItemForDetail,
+          ...approvalDetail,
+        }
+      : selectedItemForDetail;
 
   return (
     <section id="datatap_page" className="fade-in">
@@ -329,7 +353,7 @@ const DataTab = ({
                         label: "검토 완료 상태로 변경",
                         onClick: handleBulkReview,
                         className: "submit",
-                        disabled: !selectedSupportedRows.length,
+                        disabled: actionLoading || !selectedSupportedRows.length,
                       },
                     ]
                   : [
@@ -337,22 +361,22 @@ const DataTab = ({
                         label: "선택 항목 최종 승인",
                         onClick: handleBulkApprove,
                         className: "submit",
-                        disabled: !canBulkApprove,
+                        disabled: actionLoading || !canBulkApprove,
                       },
                     ]),
                 {
                   label: "선택 항목 반려",
                   onClick: handleBulkReject,
                   className: "reject",
-                  disabled: !selectedSupportedRows.length,
+                  disabled: actionLoading || !selectedSupportedRows.length,
                 },
               ]}
             />
           </div>
 
           <div style={{ display: "flex", gap: "8px" }}>
-            <button className="btn-primary" onClick={fetchData} disabled={isLoading}>
-              {isLoading ? "Loading..." : "데이터 새로고침"}
+            <button className="btn-primary" onClick={fetchData} disabled={isLoading || actionLoading}>
+              {isLoading || actionLoading ? "Loading..." : "데이터 새로고침"}
             </button>
           </div>
         </div>
@@ -395,7 +419,7 @@ const DataTab = ({
                           visibleInputs.length > 0 &&
                           visibleInputs.every((item) => selectedIds.includes(item.id))
                         }
-                        disabled={readOnlyYn}
+                        disabled={readOnlyYn || actionLoading}
                         onChange={handleToggleSelectAll}
                       />
                     </th>
@@ -490,6 +514,7 @@ const DataTab = ({
                               <button
                                 className="ob-act-btn ob-act-draft ob-detail-btn"
                                 onClick={() => handleOpenApprovalDetail(item)}
+                                disabled={actionLoading}
                               >
                                 상세 확인
                               </button>
@@ -498,7 +523,7 @@ const DataTab = ({
                                   <button
                                     className="ob-act-btn ob-act-submit"
                                     onClick={() => runAction(item, "REVIEWED")}
-                                    disabled={!supported}
+                                    disabled={actionLoading || !supported}
                                     title={unsupportedTitle}
                                   >
                                     검토 완료
@@ -507,7 +532,7 @@ const DataTab = ({
                                     type="button"
                                     className="ob-act-btn ob-act-reject"
                                     onClick={() => runAction(item, "REJECTED")}
-                                    disabled={!supported}
+                                    disabled={actionLoading || !supported}
                                     title={unsupportedTitle}
                                   >
                                     반려
@@ -518,7 +543,7 @@ const DataTab = ({
                                   <button
                                     className="ob-act-btn ob-act-submit"
                                     onClick={() => handleOpenApprovalDetail(item, "approve")}
-                                    disabled={!canApprove}
+                                    disabled={actionLoading || !canApprove}
                                     title={
                                       !supported
                                         ? unsupportedTitle
@@ -534,7 +559,7 @@ const DataTab = ({
                                     type="button"
                                     className="ob-act-btn ob-act-reject"
                                     onClick={() => runAction(item, "REJECTED")}
-                                    disabled={!supported}
+                                    disabled={actionLoading || !supported}
                                     title={unsupportedTitle}
                                   >
                                     반려
@@ -575,33 +600,33 @@ const DataTab = ({
 
       <ApprovalDetailModal
         isOpen={isDetailModalOpen}
-        onClose={() => { setIsDetailModalOpen(false); setModalActionMode(null); }}
-        metricItem={selectedItemForDetail}
+        onClose={closeDetailModal}
+        metricItem={detailMetricItem}
         viewerRole={effectiveViewerRole}
         hasConsultant={effectiveHasConsultant}
         readOnlyYn={readOnlyYn}
         modalActionMode={modalActionMode}
-        onReview={({ commentText }) => {
-          if (isActionSupported(selectedItemForDetail, readOnlyYn)) {
-            runAction(selectedItemForDetail, "REVIEWED", commentText);
+        loading={approvalDetailLoading}
+        error={approvalDetailError}
+        actionLoading={actionLoading}
+        onReview={async ({ commentText }) => {
+          const success = await runAction(selectedItemForDetail, "REVIEWED", commentText);
+          if (success) {
+            closeDetailModal();
           }
-          setIsDetailModalOpen(false);
-          setModalActionMode(null);
         }}
-        onApprove={({ commentText }) => {
-          if (isActionSupported(selectedItemForDetail, readOnlyYn)) {
-            runAction(selectedItemForDetail, "APPROVED", commentText);
+        onApprove={async ({ commentText }) => {
+          const success = await runAction(selectedItemForDetail, "APPROVED", commentText);
+          if (success) {
+            closeDetailModal();
           }
-          setIsDetailModalOpen(false);
-          setModalActionMode(null);
         }}
-        onReject={({ commentText }) => {
+        onReject={async ({ commentText }) => {
           if (!commentText?.trim()) return;
-          if (isActionSupported(selectedItemForDetail, readOnlyYn)) {
-            runAction(selectedItemForDetail, "REJECTED", commentText);
+          const success = await runAction(selectedItemForDetail, "REJECTED", commentText);
+          if (success) {
+            closeDetailModal();
           }
-          setIsDetailModalOpen(false);
-          setModalActionMode(null);
         }}
       />
 
@@ -642,9 +667,11 @@ const DataTab = ({
                 className="btn-confirm"
                 disabled={!bulkRejectReason.trim()}
                 title={!bulkRejectReason.trim() ? "Enter rejection reason." : ""}
-                onClick={() => {
-                  handleBulkAction("REJECTED", bulkRejectReason.trim());
-                  setIsBulkRejectModalOpen(false);
+                onClick={async () => {
+                  const success = await handleBulkAction("REJECTED", bulkRejectReason.trim());
+                  if (success) {
+                    setIsBulkRejectModalOpen(false);
+                  }
                 }}
               >
                 Confirm reject

--- a/frontend/src/homes/mains/DataTab.jsx
+++ b/frontend/src/homes/mains/DataTab.jsx
@@ -473,7 +473,7 @@ const DataTab = ({
                               className="ob-checkbox"
                               aria-label={`Select ${item.metricId || item.id}`}
                               checked={selectedIds.includes(item.id)}
-                              disabled={readOnlyYn}
+                              disabled={readOnlyYn || actionLoading}
                               onChange={() => toggleSelect(item.id)}
                             />
                           </td>

--- a/frontend/src/homes/mains/ManagerData.jsx
+++ b/frontend/src/homes/mains/ManagerData.jsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { useSearchParams } from "react-router";
 import "@styles/Manager.css";
 import DataTab from "./DataTab.jsx";
 import { showConfirmAlert, showDefaultAlert } from "@components/UI/ServiceAlert";
@@ -11,12 +12,20 @@ import {
   DEFAULT_REPORTING_YEAR,
   clearApprovalProject,
   fetchApprovalItems,
+  fetchOnboardingApprovalDetail,
   fetchApprovalProjects,
+  approveOnboardingApproval,
   selectApprovalProject,
+  rejectOnboardingApproval,
+  reviewOnboardingApproval,
 } from "@stores/reportSlice";
 
-const USE_LEGACY_USER_FIXTURE = true;
+const USE_LEGACY_USER_FIXTURE = STEP12_UI_FIXTURE_ENABLED;
 const PAGE_SIZE = 10;
+const SUPPORTED_APPROVAL_CYCLE_TYPES = [
+  "PRE_DMA_G0",
+  "POST_DMA_DISCLOSURE",
+];
 
 const LEGACY_USER_FIXTURE_CATEGORY_MAP = {
   general: ["General", "Business model", "Report basis", "Management"],
@@ -129,9 +138,28 @@ const runStatusLabel = (runStatus) => {
 
 const ManagerData = () => {
   const dispatch = useDispatch();
+  const [searchParams, setSearchParams] = useSearchParams();
   const approvalItems = useSelector((state) => state.report?.approval?.items ?? []);
   const approvalLoading = useSelector((state) => state.report?.loading?.approvals ?? false);
   const approvalError = useSelector((state) => state.report?.error?.approvals ?? null);
+  const approvalDetail = useSelector(
+    (state) => state.report?.approval?.selectedItemDetail ?? null
+  );
+  const approvalDetailLoading = useSelector(
+    (state) => state.report?.loading?.approvalDetail ?? false
+  );
+  const approvalDetailError = useSelector(
+    (state) => state.report?.error?.approvalDetail ?? null
+  );
+  const reviewLoading = useSelector(
+    (state) => state.report?.loading?.onboardingApprovalReview ?? false
+  );
+  const approveLoading = useSelector(
+    (state) => state.report?.loading?.onboardingApprovalApprove ?? false
+  );
+  const rejectLoading = useSelector(
+    (state) => state.report?.loading?.onboardingApprovalReject ?? false
+  );
   const approvalProjectsFromStore = useSelector(
     (state) => state.report?.approval?.projects ?? []
   );
@@ -169,7 +197,14 @@ const ManagerData = () => {
     selectedCompany?.reporting_year ??
     selectedCompany?.reportingYear ??
     DEFAULT_REPORTING_YEAR;
-  const cycleType = "PRE_DMA_G0";
+  const cycleTypeQuery = String(searchParams.get("cycleType") || "")
+    .trim()
+    .toUpperCase();
+  const [approvalCycleType, setApprovalCycleType] = useState(
+    SUPPORTED_APPROVAL_CYCLE_TYPES.includes(cycleTypeQuery)
+      ? cycleTypeQuery
+      : "PRE_DMA_G0"
+  );
 
   const selectedCompanyName =
     selectedCompany?.name ??
@@ -215,6 +250,37 @@ const ManagerData = () => {
   const displayApprovalProject =
     selectedApprovalProject ?? fallbackApprovalProject;
 
+  useEffect(() => {
+    if (
+      SUPPORTED_APPROVAL_CYCLE_TYPES.includes(cycleTypeQuery) &&
+      cycleTypeQuery !== approvalCycleType
+    ) {
+      queueMicrotask(() => {
+        setApprovalCycleType(cycleTypeQuery);
+        setSelectedIds([]);
+        setDataPage(1);
+        setIsRejectModalOpen(false);
+      });
+    }
+  }, [approvalCycleType, cycleTypeQuery]);
+
+  const handleApprovalCycleTypeChange = useCallback(
+    (event) => {
+      const nextCycleType = String(event.target.value || "").trim().toUpperCase();
+      const normalized = SUPPORTED_APPROVAL_CYCLE_TYPES.includes(nextCycleType)
+        ? nextCycleType
+        : "PRE_DMA_G0";
+      setApprovalCycleType(normalized);
+      setSelectedIds([]);
+      setDataPage(1);
+      setIsRejectModalOpen(false);
+      const nextParams = new URLSearchParams(searchParams);
+      nextParams.set("cycleType", normalized);
+      setSearchParams(nextParams);
+    },
+    [searchParams, setSearchParams]
+  );
+
   const handleSelectApprovalProject = useCallback(
     (project) => {
       dispatch(selectApprovalProject(project));
@@ -227,14 +293,18 @@ const ManagerData = () => {
 
   useEffect(() => {
     dispatch(clearApprovalProject());
-    setInputs([]);
-    setSelectedIds([]);
-    setDataPage(1);
+    queueMicrotask(() => {
+      setInputs([]);
+      setSelectedIds([]);
+      setDataPage(1);
+    });
 
     if (!companyId) return;
 
     if (STEP12_UI_FIXTURE_ENABLED) {
-      setIsApprovalProjectModalOpen(true);
+      queueMicrotask(() => {
+        setIsApprovalProjectModalOpen(true);
+      });
       return;
     }
 
@@ -268,7 +338,7 @@ const ManagerData = () => {
         fetchApprovalItems({
           companyId,
           reportingYear: approvalReportingYear,
-          cycleType,
+          cycleType: approvalCycleType,
           assignedOnlyYn: true,
         })
       ).unwrap();
@@ -279,20 +349,24 @@ const ManagerData = () => {
       setInputs([]);
     }
   }, [
+    approvalCycleType,
     approvalReportingYear,
     companyId,
-    cycleType,
     dispatch,
     selectedApprovalProject,
   ]);
 
   useEffect(() => {
-    fetchData();
+    queueMicrotask(() => {
+      fetchData();
+    });
   }, [fetchData]);
 
   useEffect(() => {
     if (STEP12_UI_FIXTURE_ENABLED) return;
-    setInputs(safeArray(approvalItems).map(mapApprovalItemToInput));
+    queueMicrotask(() => {
+      setInputs(safeArray(approvalItems).map(mapApprovalItemToInput));
+    });
   }, [approvalItems]);
 
   const kpi = useMemo(
@@ -315,10 +389,56 @@ const ManagerData = () => {
     [inputs]
   );
 
+  const isLoading = approvalLoading || approvalProjectsLoading;
+  const approvalMutationLoading = reviewLoading || approveLoading || rejectLoading;
+
+  const buildApprovalPayload = useCallback(
+    (metricId, commentText = "") => ({
+      companyId,
+      reportingYear: approvalReportingYear,
+      cycleType: approvalCycleType,
+      metricId,
+      ...(commentText?.trim() ? { commentText: commentText.trim() } : {}),
+    }),
+    [approvalCycleType, approvalReportingYear, companyId]
+  );
+
+  const dispatchApprovalMutation = useCallback(
+    async (metricId, status, commentText = "") => {
+      const payload = buildApprovalPayload(metricId, commentText);
+      if (status === "REVIEWED") {
+        return dispatch(reviewOnboardingApproval(payload)).unwrap();
+      }
+      if (status === "APPROVED") {
+        return dispatch(approveOnboardingApproval(payload)).unwrap();
+      }
+      if (status === "REJECTED") {
+        return dispatch(rejectOnboardingApproval(payload)).unwrap();
+      }
+      throw new Error(`Unsupported approval action: ${status}`);
+    },
+    [buildApprovalPayload, dispatch]
+  );
+
+  const handleFetchApprovalDetail = useCallback(
+    async (metricId) => {
+      const response = await dispatch(
+        fetchOnboardingApprovalDetail({
+          companyId,
+          reportingYear: approvalReportingYear,
+          metricId,
+          cycleType: approvalCycleType,
+        })
+      ).unwrap();
+      return response?.data || response;
+    },
+    [approvalCycleType, approvalReportingYear, companyId, dispatch]
+  );
+
   const handleAction = async (id, status, commentText = "") => {
     if (selectedProjectReadOnlyYn) {
       showDefaultAlert("Notice", "Completed projects are read-only.", "info");
-      return;
+      return false;
     }
 
     const normalizedStatus = normalizeStatus(status);
@@ -326,54 +446,69 @@ const ManagerData = () => {
       setRejectTargetId(id);
       setRejectReason("");
       setIsRejectModalOpen(true);
-      return;
+      return false;
     }
 
     const ok = await showConfirmAlert("Confirm", "Process this item?", "question");
-    if (!ok) return;
+    if (!ok) return false;
 
-    setInputs((prev) =>
-      prev.map((item) =>
-        item.id === id
-          ? {
-              ...item,
-              status: normalizedStatus,
-              approvalStatus: normalizedStatus,
-              ...(normalizedStatus === "REJECTED"
-                ? { reason: commentText.trim() }
-                : {}),
-            }
-          : item
-      )
-    );
+    try {
+      await dispatchApprovalMutation(id, normalizedStatus, commentText);
+      await fetchData();
+      showDefaultAlert("완료", "승인 작업이 처리되었습니다.", "success");
+      return true;
+    } catch (error) {
+      console.error(error);
+      showDefaultAlert(
+        "오류",
+        error?.message || error?.detail || "승인 작업 처리에 실패했습니다.",
+        "error"
+      );
+      return false;
+    }
   };
 
   const handleBulkAction = async (status, commentText = "") => {
     if (selectedProjectReadOnlyYn) {
       showDefaultAlert("Notice", "Completed projects are read-only.", "info");
-      return;
+      return false;
     }
-    if (!selectedIds.length) return;
+    if (!selectedIds.length) return false;
 
     const ok = await showConfirmAlert("Bulk action", "Continue?", "question");
-    if (!ok) return;
+    if (!ok) return false;
 
     const normalizedStatus = normalizeStatus(status);
-    setInputs((prev) =>
-      prev.map((item) =>
-        selectedIds.includes(item.id)
-          ? {
-              ...item,
-              status: normalizedStatus,
-              approvalStatus: normalizedStatus,
-              ...(normalizedStatus === "REJECTED"
-                ? { reason: commentText.trim() }
-                : {}),
-            }
-          : item
-      )
-    );
+    if (normalizedStatus === "REJECTED" && !commentText?.trim()) {
+      showDefaultAlert("Notice", "Enter rejection reason.", "info");
+      return false;
+    }
+
+    const succeeded = [];
+    const failed = [];
+    for (const metricId of selectedIds) {
+      try {
+        await dispatchApprovalMutation(metricId, normalizedStatus, commentText);
+        succeeded.push(metricId);
+      } catch (error) {
+        failed.push({
+          metricId,
+          message: error?.message || error?.detail || "처리 실패",
+        });
+      }
+    }
+    await fetchData();
     setSelectedIds([]);
+    if (failed.length) {
+      showDefaultAlert(
+        "주의",
+        `${succeeded.length}건 처리, ${failed.length}건 실패했습니다.`,
+        "warning"
+      );
+      return false;
+    }
+    showDefaultAlert("완료", `${succeeded.length}건 처리되었습니다.`, "success");
+    return true;
   };
 
   const handleMainCategoryChange = useCallback((category) => {
@@ -381,8 +516,6 @@ const ManagerData = () => {
     setActiveSubCategory("all");
     setDataPage(1);
   }, []);
-
-  const isLoading = approvalLoading || approvalProjectsLoading;
 
   return (
     <div id="manager_page">
@@ -412,6 +545,27 @@ const ManagerData = () => {
           </div>
 
           <div className="approval-project-context-actions">
+            <label
+              className="approval-cycle-type-control"
+              style={{ display: "flex", alignItems: "center", gap: "8px" }}
+            >
+              <span className="approval-project-context-label">Approval scope</span>
+              <select
+                value={approvalCycleType}
+                onChange={handleApprovalCycleTypeChange}
+                disabled={isLoading || approvalMutationLoading}
+                style={{
+                  height: "34px",
+                  border: "1px solid #d1d5db",
+                  borderRadius: "6px",
+                  padding: "0 8px",
+                  fontSize: "0.85rem",
+                }}
+              >
+                <option value="PRE_DMA_G0">사전 경영일반 승인</option>
+                <option value="POST_DMA_DISCLOSURE">보고서 연결 공시 승인</option>
+              </select>
+            </label>
             {displayApprovalProject.readOnlyYn && (
               <span className="approval-project-readonly-chip">Read-only</span>
             )}
@@ -489,6 +643,11 @@ const ManagerData = () => {
               fetchData={fetchData}
               setDataPage={setDataPage}
               handleAction={handleAction}
+              actionLoading={approvalMutationLoading}
+              approvalDetail={approvalDetail}
+              approvalDetailLoading={approvalDetailLoading}
+              approvalDetailError={approvalDetailError}
+              fetchApprovalDetail={handleFetchApprovalDetail}
             />
           </div>
         )}
@@ -530,8 +689,10 @@ const ManagerData = () => {
                       showDefaultAlert("Notice", "Enter rejection reason.", "info");
                       return;
                     }
-                    await handleAction(rejectTargetId, "REJECTED", rejectReason);
-                    setIsRejectModalOpen(false);
+                    const success = await handleAction(rejectTargetId, "REJECTED", rejectReason);
+                    if (success) {
+                      setIsRejectModalOpen(false);
+                    }
                   }}
                 >
                   Confirm reject

--- a/frontend/src/homes/mains/ManagerData.jsx
+++ b/frontend/src/homes/mains/ManagerData.jsx
@@ -105,7 +105,11 @@ const mapApprovalItemToInput = (item = {}) => {
     )
       ? "SUBMITTED"
       : "DRAFT",
-    reviewStatus: ["APPROVED", "REJECTED"].includes(approvalStatus)
+    reviewStatus: [
+      "REVIEWED",
+      "APPROVED",
+      "REJECTED",
+    ].includes(approvalStatus)
       ? "REVIEWED"
       : "PENDING",
     inputCompletedCount: completedCount,

--- a/frontend/src/homes/mains/modal/ApprovalDetailModal.jsx
+++ b/frontend/src/homes/mains/modal/ApprovalDetailModal.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
-import { showDefaultAlert } from "@components/UI/ServiceAlert";
+import { STEP12_UI_FIXTURE_ENABLED } from "@/dev/step12UiPreview/config";
 
 const FIXTURE_ATOMIC_ITEMS = [
   { atomicMetricId: "E1-1-a", atomicMetricName: "Scope 1 온실가스 직접 배출량", value: "12,450", unit: "tCO₂e", inputType: "MANUAL_NUMBER", evidenceCount: 2, inputStatus: "COMPLETED" },
@@ -17,15 +17,20 @@ export default function ApprovalDetailModal({
   hasConsultant = false,
   readOnlyYn = false,
   modalActionMode = null,
+  loading = false,
+  error = null,
+  actionLoading = false,
   onReview,
   onApprove,
   onReject,
 }) {
-  const [rejectReason, setRejectReason] = useState("");
+  const [commentText, setCommentText] = useState("");
 
   useEffect(() => {
     if (isOpen) {
-      setRejectReason("");
+      queueMicrotask(() => {
+        setCommentText("");
+      });
     }
   }, [isOpen]);
 
@@ -36,20 +41,30 @@ export default function ApprovalDetailModal({
     String(viewerRole || "").toUpperCase().includes("CONSULTANT");
   const isReviewed = metricItem.reviewStatus === "REVIEWED";
   const canApprove = isConsultant ? false : !hasConsultant || isReviewed;
-  const rejectDisabled = readOnlyYn || !rejectReason.trim();
-  const approveDisabled = readOnlyYn || !canApprove;
+  const rejectDisabled = readOnlyYn || actionLoading || !commentText.trim();
+  const approveDisabled = readOnlyYn || actionLoading || !canApprove;
   const metricId = metricItem.metricId || metricItem.id;
   const isApproveMode = modalActionMode === "approve";
 
-  const atomicItems = metricItem.atomicItems || FIXTURE_ATOMIC_ITEMS;
+  const atomicItems =
+    metricItem.atomicItems ??
+    (STEP12_UI_FIXTURE_ENABLED ? FIXTURE_ATOMIC_ITEMS : []);
   const totalEvidenceCount = atomicItems.reduce((sum, item) => sum + (item.evidenceCount || 0), 0);
 
-  const handleApproveClick = () => {
-    showDefaultAlert("안내", "최종 승인 API 연결은 후속 단계에서 진행됩니다.", "info");
+  const handleApproveClick = async () => {
+    if (approveDisabled || actionLoading) return;
+    await onApprove?.({
+      metricId,
+      commentText: commentText.trim(),
+    });
   };
 
-  const handleReviewClick = () => {
-    showDefaultAlert("안내", "검토 완료 API 연결은 후속 단계에서 진행됩니다.", "info");
+  const handleReviewClick = async () => {
+    if (readOnlyYn || actionLoading) return;
+    await onReview?.({
+      metricId,
+      commentText: commentText.trim(),
+    });
   };
 
   return createPortal(
@@ -85,6 +100,20 @@ export default function ApprovalDetailModal({
             </div>
           )}
 
+          {loading && (
+            <div className="alert alert-info" style={readOnlyAlertStyle}>
+              상세 정보를 불러오는 중입니다.
+            </div>
+          )}
+
+          {error && (
+            <div className="alert alert-warning" style={readOnlyAlertStyle}>
+              {typeof error === "string"
+                ? error
+                : error.message || "승인 상세 조회에 실패했습니다."}
+            </div>
+          )}
+
           {isApproveMode && (
             <div style={{ marginBottom: '16px', padding: '12px', background: '#fffbeb', borderRadius: '8px', border: '1px solid #fde68a', fontSize: '0.85rem', color: '#92400e' }}>
               최종 승인 전에 아래 Atomic 상세 항목을 검토하세요.
@@ -116,27 +145,55 @@ export default function ApprovalDetailModal({
                   </tr>
                 </thead>
                 <tbody>
-                  {atomicItems.map((atomic, idx) => {
-                    const statusLabel = atomic.inputStatus === "COMPLETED" ? "완료" : atomic.inputStatus === "IN_PROGRESS" ? "작성중" : "미입력";
-                    const statusCls = atomic.inputStatus === "COMPLETED" ? "#16a34a" : atomic.inputStatus === "IN_PROGRESS" ? "#d97706" : "#94a3b8";
-                    return (
-                      <tr key={atomic.atomicMetricId || idx} style={tableRowStyle}>
-                        <td style={{ ...tdStyle, fontWeight: 600, fontSize: "0.8rem", color: "#475569" }}>{atomic.atomicMetricId}</td>
-                        <td style={tdStyle}>{atomic.atomicMetricName}</td>
-                        <td style={{ ...tdStyle, fontWeight: 600 }}>{atomic.value || "-"}</td>
-                        <td style={{ ...tdStyle, color: "#64748b" }}>{atomic.unit || "-"}</td>
-                        <td style={tdStyle}>
-                          <span style={{ fontSize: "11px", background: "#f1f5f9", padding: "2px 8px", borderRadius: "4px" }}>
-                            {atomic.inputType || "-"}
-                          </span>
-                        </td>
-                        <td style={{ ...tdStyle, textAlign: "center" }}>{atomic.evidenceCount || 0}</td>
-                        <td style={tdStyle}>
-                          <span style={{ fontSize: "12px", fontWeight: 600, color: statusCls }}>{statusLabel}</span>
-                        </td>
-                      </tr>
-                    );
-                  })}
+                  {atomicItems.length === 0 ? (
+                    <tr>
+                      <td colSpan="7" style={{ ...tdStyle, textAlign: "center", color: "#64748b" }}>
+                        표시할 Atomic 입력 상세가 없습니다.
+                      </td>
+                    </tr>
+                  ) : (
+                    atomicItems.map((atomic, idx) => {
+                      const normalizedStatus = String(atomic.inputStatus || "").trim().toUpperCase();
+                      const statusLabel =
+                        normalizedStatus === "COMPLETED" || normalizedStatus === "APPROVED"
+                          ? "완료"
+                          : normalizedStatus === "IN_PROGRESS" ||
+                              normalizedStatus === "SUBMITTED" ||
+                              normalizedStatus === "REVIEWED"
+                            ? "작성중"
+                            : "미입력";
+                      const statusCls =
+                        normalizedStatus === "COMPLETED" || normalizedStatus === "APPROVED"
+                          ? "#16a34a"
+                          : normalizedStatus === "IN_PROGRESS" ||
+                              normalizedStatus === "SUBMITTED" ||
+                              normalizedStatus === "REVIEWED"
+                            ? "#d97706"
+                            : "#94a3b8";
+                      const value =
+                        atomic.value ??
+                        atomic.valueText ??
+                        atomic.valueNumeric ??
+                        "-";
+                      return (
+                        <tr key={atomic.atomicMetricId || idx} style={tableRowStyle}>
+                          <td style={{ ...tdStyle, fontWeight: 600, fontSize: "0.8rem", color: "#475569" }}>{atomic.atomicMetricId}</td>
+                          <td style={tdStyle}>{atomic.atomicName || atomic.atomicMetricName || "-"}</td>
+                          <td style={{ ...tdStyle, fontWeight: 600 }}>{value}</td>
+                          <td style={{ ...tdStyle, color: "#64748b" }}>{atomic.unit || "-"}</td>
+                          <td style={tdStyle}>
+                            <span style={{ fontSize: "11px", background: "#f1f5f9", padding: "2px 8px", borderRadius: "4px" }}>
+                              {atomic.inputMode || atomic.inputType || "-"}
+                            </span>
+                          </td>
+                          <td style={{ ...tdStyle, textAlign: "center" }}>{atomic.evidenceCount || 0}</td>
+                          <td style={tdStyle}>
+                            <span style={{ fontSize: "12px", fontWeight: 600, color: statusCls }}>{statusLabel}</span>
+                          </td>
+                        </tr>
+                      );
+                    })
+                  )}
                 </tbody>
               </table>
             </div>
@@ -155,13 +212,13 @@ export default function ApprovalDetailModal({
           </div>
 
           <div style={{ marginBottom: "8px" }}>
-            <h4 style={sectionTitleStyle}>Rejection reason</h4>
+            <h4 style={sectionTitleStyle}>검토 의견 / 반려 사유</h4>
             <textarea
               style={textareaStyle}
-              placeholder="Enter rejection reason."
-              value={rejectReason}
-              disabled={readOnlyYn}
-              onChange={(event) => setRejectReason(event.target.value)}
+              placeholder="검토 의견 또는 반려 사유를 입력하세요."
+              value={commentText}
+              disabled={readOnlyYn || actionLoading}
+              onChange={(event) => setCommentText(event.target.value)}
             />
           </div>
         </div>
@@ -179,12 +236,12 @@ export default function ApprovalDetailModal({
               cursor: rejectDisabled ? "not-allowed" : "pointer",
               opacity: rejectDisabled ? 0.5 : 1,
             }}
-            onClick={() => onReject?.({ metricId, commentText: rejectReason })}
+            onClick={() => onReject?.({ metricId, commentText: commentText.trim() })}
             disabled={rejectDisabled}
             title={
               readOnlyYn
                 ? "Completed projects are read-only."
-                : !rejectReason.trim()
+                : !commentText.trim()
                   ? "Enter rejection reason."
                   : ""
             }
@@ -198,11 +255,11 @@ export default function ApprovalDetailModal({
               className="ob-btn ob-btn-primary"
               style={{
                 ...primaryButtonStyle,
-                cursor: readOnlyYn ? "not-allowed" : "pointer",
-                opacity: readOnlyYn ? 0.5 : 1,
+                cursor: readOnlyYn || actionLoading ? "not-allowed" : "pointer",
+                opacity: readOnlyYn || actionLoading ? 0.5 : 1,
               }}
               onClick={handleReviewClick}
-              disabled={readOnlyYn}
+              disabled={readOnlyYn || actionLoading}
               title={readOnlyYn ? "Completed projects are read-only." : ""}
             >
               Mark reviewed

--- a/frontend/src/homes/onboards/OnBoard.jsx
+++ b/frontend/src/homes/onboards/OnBoard.jsx
@@ -116,6 +116,20 @@ const resolveOnboardingCycleType = (workflow, requestedCycleType) => {
   return workflowValue === "POST_DMA_DISCLOSURE" ? "POST_DMA_DISCLOSURE" : "PRE_DMA_G0";
 };
 
+const resolveRollupContext = (cycleType) => {
+  const normalized = String(cycleType || "").trim().toUpperCase();
+  if (normalized === "POST_DMA_DISCLOSURE") {
+    return {
+      rollupPurposeCode: "REPORT_DISCLOSURE",
+      metricScopeCode: "SELECTED_DISCLOSURE",
+    };
+  }
+  return {
+    rollupPurposeCode: "DMA_PRECHECK",
+    metricScopeCode: "G0_02_FINANCIAL_BASIS",
+  };
+};
+
 const mergeAssignmentIntoItems = (items = [], assignments = []) => {
   const assignmentByMetric = new Map((assignments || []).map((item) => [item.metricId, item]));
   return items.map((item) => {
@@ -207,8 +221,9 @@ const OnboardingWorkflowCta = ({
   onBasisModalOpen,
   onCalculated,
   onCtaClick,
-  onReqModalOpen,
   onTransferModalOpen,
+  rollupPurposeCode,
+  metricScopeCode,
   rollupScenario,
 }) => {
   if (variant === "noRun" || isNoRunWorkflow(workflow)) {
@@ -251,8 +266,9 @@ const OnboardingWorkflowCta = ({
           <RollupSummaryPanel
             batchId={activeBatchId}
             onCalculated={onCalculated}
+            rollupPurposeCode={rollupPurposeCode}
+            metricScopeCode={metricScopeCode}
             rollupScenario={rollupScenario}
-            onManageRequests={() => onReqModalOpen?.()}
             onSendSource={() => onTransferModalOpen?.()}
           />
         )}
@@ -290,7 +306,6 @@ const OnboardingMetricTable = ({
   selectedMetricIds,
   onSelectMetric,
   onToggleSelectAll,
-  onRowAssignRequested,
   onBulkAssignRequested,
   onOpenMetric,
   onRetry,
@@ -530,12 +545,17 @@ const OnBoard = () => {
     () => resolveOnboardingCycleType(displayWorkflow, cycleTypeQuery),
     [displayWorkflow, cycleTypeQuery]
   );
+  const activeRollupContext = useMemo(
+    () => resolveRollupContext(activeCycleType),
+    [activeCycleType]
+  );
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedItem, setSelectedItem] = useState(null);
   const [isBasisModalOpen, setIsBasisModalOpen] = useState(false);
   const [isSubReqModalOpen, setIsSubReqModalOpen] = useState(false);
   const [isSubTransferModalOpen, setIsSubTransferModalOpen] = useState(false);
+  const [activeSourceCycleId, setActiveSourceCycleId] = useState(null);
 
   // New States for UI-1 & UI-2
   const [selectedMetricIds, setSelectedMetricIds] = useState([]);
@@ -565,6 +585,7 @@ const OnBoard = () => {
   const initializeOnboarding = useCallback(async () => {
     if (!companyId) {
       dispatch(resetReportState());
+      setActiveSourceCycleId(null);
       return;
     }
 
@@ -575,11 +596,13 @@ const OnBoard = () => {
       const nextWorkflow = workflowRes?.data || workflowRes;
 
       if (isNoRunWorkflow(nextWorkflow)) {
+        setActiveSourceCycleId(null);
         setIsBasisModalOpen(true);
         return;
       }
 
       const nextCycleType = resolveOnboardingCycleType(nextWorkflow, cycleTypeQuery);
+      const nextRollupContext = resolveRollupContext(nextCycleType);
       const runId = nextWorkflow.runId;
       let sourceCycleId;
 
@@ -591,20 +614,15 @@ const OnBoard = () => {
         const initializedScope = initializedRes?.data || initializedRes;
         sourceCycleId = initializedScope?.cycleId;
       }
+      setActiveSourceCycleId(sourceCycleId ?? null);
 
       if (nextWorkflow?.reportBasisType === "CONSOLIDATED") {
         const activeRes = await dispatch(
           fetchActiveRollupBatch({
             runId,
             sourceCycleId,
-            rollupPurposeCode:
-              nextCycleType === "POST_DMA_DISCLOSURE"
-                ? "REPORT_DISCLOSURE"
-                : "DMA_PRECHECK",
-            metricScopeCode:
-              nextCycleType === "POST_DMA_DISCLOSURE"
-                ? "SELECTED_DISCLOSURE"
-                : "G0_02_FINANCIAL_BASIS",
+            rollupPurposeCode: nextRollupContext.rollupPurposeCode,
+            metricScopeCode: nextRollupContext.metricScopeCode,
           })
         ).unwrap();
 
@@ -638,7 +656,7 @@ const OnBoard = () => {
 
   useEffect(() => {
     dispatch(resetReportState());
-    initializeOnboarding();
+    Promise.resolve().then(() => initializeOnboarding());
   }, [
     dispatch,
     initializeOnboarding,
@@ -891,8 +909,9 @@ const OnBoard = () => {
                 isNoRunWorkflow={isNoRunWorkflow}
                 onCalculated={() => initializeOnboarding()}
                 onCtaClick={handleCtaClick}
-                onReqModalOpen={() => setIsSubReqModalOpen(true)}
                 onTransferModalOpen={() => setIsSubTransferModalOpen(true)}
+                rollupPurposeCode={activeRollupContext.rollupPurposeCode}
+                metricScopeCode={activeRollupContext.metricScopeCode}
                 rollupScenario={previewRollupScenario}
               />
 
@@ -903,7 +922,6 @@ const OnBoard = () => {
                 selectedMetricIds={selectedMetricIds}
                 onSelectMetric={handleSelectMetric}
                 onToggleSelectAll={handleToggleSelectAll}
-                onRowAssignRequested={handleRowAssignRequested}
                 onBulkAssignRequested={handleBulkAssignRequested}
                 onOpenMetric={(item, subMetrics) => {
                   setSelectedItem({
@@ -914,6 +932,22 @@ const OnBoard = () => {
                 }}
                 onRetry={initializeOnboarding}
                 viewerRole={viewerRole}
+              />
+              <BatchActionBar
+                selectedCount={selectedMetricIds.length}
+                actions={[
+                  {
+                    label: "담당자 일괄 지정",
+                    onClick: handleBulkAssignRequested,
+                    className: "save",
+                  },
+                  {
+                    label: "담당자 일괄 해제",
+                    onClick: handleBulkUnassignRequested,
+                    className: "cancel",
+                    disabled: !selectedMetricIds.length,
+                  },
+                ]}
               />
               <OnboardingWorkflowCta
                 loadingWorkflow={loadingWorkflow}
@@ -949,8 +983,14 @@ const OnBoard = () => {
         isOpen={isSubReqModalOpen}
         onClose={() => setIsSubReqModalOpen(false)}
         runId={workflow?.runId}
-        onRequested={async (batch) => {
-          dispatch(setActiveBatchId(batch.batchId));
+        reportingYear={reportingYear}
+        sourceCycleId={activeSourceCycleId}
+        rollupPurposeCode={activeRollupContext.rollupPurposeCode}
+        metricScopeCode={activeRollupContext.metricScopeCode}
+        onRequested={async (batchId) => {
+          if (batchId) {
+            dispatch(setActiveBatchId(batchId));
+          }
           setIsSubReqModalOpen(false);
           await initializeOnboarding();
         }}
@@ -959,9 +999,14 @@ const OnBoard = () => {
       <SubsidiaryTransferModal
         isOpen={isSubTransferModalOpen}
         onClose={() => setIsSubTransferModalOpen(false)}
+        reportingYear={reportingYear}
         onTransferred={async (batchId) => {
           dispatch(setActiveBatchId(batchId));
           await initializeOnboarding();
+        }}
+        onNavigateToInput={({ url }) => {
+          setIsSubTransferModalOpen(false);
+          navigate(url);
         }}
       />
 

--- a/frontend/src/homes/onboards/OnBoard.jsx
+++ b/frontend/src/homes/onboards/OnBoard.jsx
@@ -44,6 +44,7 @@ import {
   resetReportState,
   saveOnboardingMetric,
   setActiveBatchId,
+  submitOnboardingApproval,
 } from "@stores/reportSlice";
 
 const isNoRunWorkflow = (workflow) => workflow?.workflowStep === "NO_RUN";
@@ -736,13 +737,36 @@ const OnBoard = () => {
 
       await dispatch(saveOnboardingMetric({ metricId, payload })).unwrap();
 
-      showDefaultAlert(
-        "완료",
-        status === "DRAFT" ? "임시저장이 완료되었습니다." : "데이터 제출이 완료되었습니다.",
-        "success"
-      );
-      setIsModalOpen(false);
-      await initializeOnboarding();
+      if (status === "DRAFT") {
+        showDefaultAlert("완료", "임시저장이 완료되었습니다.", "success");
+        setIsModalOpen(false);
+        await initializeOnboarding();
+        return;
+      }
+
+      try {
+        await dispatch(
+          submitOnboardingApproval({
+            companyId,
+            reportingYear,
+            metricId,
+            cycleType: activeCycleType,
+          })
+        ).unwrap();
+        showDefaultAlert("완료", "승인 요청이 완료되었습니다.", "success");
+        setIsModalOpen(false);
+        await initializeOnboarding();
+      } catch (submitError) {
+        console.error(submitError);
+        const detail =
+          submitError?.message || submitError?.detail || submitError?.error?.message || "";
+        showDefaultAlert(
+          "오류",
+          `입력값은 저장되었지만 승인 요청에 실패했습니다.${detail ? `\n${detail}` : ""}`,
+          "error"
+        );
+        await initializeOnboarding();
+      }
     } catch (error) {
       console.error(error);
       showDefaultAlert("오류", "처리 중 오류가 발생했습니다.", "error");

--- a/frontend/src/homes/onboards/OnBoard.jsx
+++ b/frontend/src/homes/onboards/OnBoard.jsx
@@ -213,6 +213,7 @@ const OnboardingStatCards = ({ stats, g0ProfileStatus }) => {
 
 const OnboardingWorkflowCta = ({
   activeBatchId,
+  hasAnySubsidiaryRequest,
   hasPendingSubsidiaryRequest,
   loadingWorkflow,
   variant = "action",
@@ -226,6 +227,8 @@ const OnboardingWorkflowCta = ({
   metricScopeCode,
   rollupScenario,
 }) => {
+  const isWaitingRollup = workflow?.nextAction === "WAIT_ROLLUP";
+
   if (variant === "noRun" || isNoRunWorkflow(workflow)) {
     return (
       <>
@@ -250,14 +253,14 @@ const OnboardingWorkflowCta = ({
   if (variant === "top") {
     return (
       <>
-        {hasPendingSubsidiaryRequest && (
+        {hasAnySubsidiaryRequest && (
           <div style={{ display: "flex", justifyContent: "flex-end", padding: "16px 24px 0 24px" }}>
             <button
               className="ob1-btn-input"
               onClick={onTransferModalOpen}
               style={{ padding: "8px 16px", background: "#f8fafc", color: "#1e293b", border: "1px solid #cbd5e1" }}
             >
-              지주사 요청 확인 및 전송
+              {hasPendingSubsidiaryRequest ? "지주사 요청 확인 및 전송" : "지주사 요청 이력"}
             </button>
           </div>
         )}
@@ -280,8 +283,8 @@ const OnboardingWorkflowCta = ({
     <div className="ob1-cta-container">
       <button
         className="ob1-btn-cta"
-        onClick={onCtaClick}
-        disabled={loadingWorkflow}
+        onClick={isWaitingRollup ? undefined : onCtaClick}
+        disabled={loadingWorkflow || isWaitingRollup}
       >
         {loadingWorkflow
           ? "로딩 중..."
@@ -292,7 +295,7 @@ const OnboardingWorkflowCta = ({
               : workflow.nextAction === "REQUEST_ROLLUP"
                 ? "자회사 데이터 요청하기"
                 : workflow.nextAction === "WAIT_ROLLUP"
-                  ? "롤업 대기"
+                  ? "자회사 데이터 대기"
                   : "입력 상태 확인"}
       </button>
     </div>
@@ -574,6 +577,10 @@ const OnBoard = () => {
   const g0ProfileStatus = useMemo(() => getProfileStatusFromItems(g0Items), [g0Items]);
   const hasPendingSubsidiaryRequest = useMemo(
     () => requests.some(isPendingSubsidiaryRequest),
+    [requests]
+  );
+  const hasAnySubsidiaryRequest = useMemo(
+    () => requests.length > 0,
     [requests]
   );
   const workflowError = workflowErrorPayload?.message || null;
@@ -903,6 +910,7 @@ const OnBoard = () => {
               <OnboardingWorkflowCta
                 variant="top"
                 activeBatchId={activeBatchId}
+                hasAnySubsidiaryRequest={hasAnySubsidiaryRequest}
                 hasPendingSubsidiaryRequest={hasPendingSubsidiaryRequest}
                 loadingWorkflow={loadingWorkflow}
                 workflow={displayWorkflow}
@@ -1000,8 +1008,7 @@ const OnBoard = () => {
         isOpen={isSubTransferModalOpen}
         onClose={() => setIsSubTransferModalOpen(false)}
         reportingYear={reportingYear}
-        onTransferred={async (batchId) => {
-          dispatch(setActiveBatchId(batchId));
+        onTransferred={async () => {
           await initializeOnboarding();
         }}
         onNavigateToInput={({ url }) => {

--- a/frontend/src/homes/onboards/RollupSummaryPanel.jsx
+++ b/frontend/src/homes/onboards/RollupSummaryPanel.jsx
@@ -1,7 +1,8 @@
-import { useState, useEffect } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import {
   calculateRollupBatch,
+  fetchRollupBatchSources,
   fetchRollupBatchStatus,
 } from "@stores/reportSlice";
 import { showDefaultAlert } from "@components/UI/ServiceAlert";
@@ -9,117 +10,112 @@ import "@styles/onboarding1.css";
 import { STEP12_UI_FIXTURE_ENABLED } from "@/dev/step12UiPreview/config";
 import { getFixtureRollupStatus } from "@/dev/step12UiPreview/fixtures";
 
-const RollupSummaryPanel = ({ batchId, onCalculated, rollupScenario, onManageRequests, onSendSource, onCalculate }) => {
+const purposeLabel = (code) => {
+  const value = String(code || "").toUpperCase();
+  if (value === "REPORT_DISCLOSURE") return "보고서 연결 공시";
+  if (value === "DMA_PRECHECK") return "DMA 사전 계산";
+  return value || "-";
+};
+
+const readinessLabel = (status) => {
+  const value = String(status || "").toUpperCase();
+  if (value === "READY") return "전송 가능";
+  if (value === "PARTIAL") return "입력 진행중";
+  if (value === "NOT_STARTED") return "미입력";
+  return status || "-";
+};
+
+const transferLabel = (status) => {
+  const value = String(status || "").toLowerCase();
+  if (value === "received") return "수신 완료";
+  if (value === "sent") return "전송 완료";
+  if (value === "not_sent") return "미전송";
+  return status || "-";
+};
+
+const approvalLabel = (status) => {
+  const value = String(status || "").toLowerCase();
+  if (value === "approved") return "승인 완료";
+  if (value === "reviewed") return "검토 완료";
+  if (value === "rejected") return "반려";
+  if (value === "pending" || value === "submitted") return "승인 대기";
+  return status || "-";
+};
+
+const numberOrZero = (value) => Number(value || 0);
+
+const RollupSummaryPanel = ({
+  batchId,
+  onCalculated,
+  rollupScenario,
+  rollupPurposeCode = "DMA_PRECHECK",
+  metricScopeCode = "G0_02_FINANCIAL_BASIS",
+  onCalculate,
+}) => {
   const dispatch = useDispatch();
   const reduxStatusInfo = useSelector((state) => state.report.rollup.batchStatus);
-  const loading = useSelector((state) => state.report.loading.batchStatus);
+  const batchSources = useSelector((state) => state.report.rollup.batchSources);
+  const loadingStatus = useSelector((state) => state.report.loading.batchStatus);
+  const loadingSources = useSelector((state) => state.report.loading.rollupBatchSources);
+  const calculatingRedux = useSelector((state) => state.report.loading.calculateBatch);
+  const statusError = useSelector((state) => state.report.error.batchStatus);
+  const sourceError = useSelector((state) => state.report.error.rollupBatchSources);
+  const [showSources, setShowSources] = useState(false);
   const [calculating, setCalculating] = useState(false);
   const [error, setError] = useState(null);
 
-  useEffect(() => {
-    if (!batchId) return;
-    fetchStatus();
-  }, [batchId]);
+  const statusInfo = useMemo(() => {
+    if (STEP12_UI_FIXTURE_ENABLED && getFixtureRollupStatus(rollupScenario)) {
+      return getFixtureRollupStatus(rollupScenario);
+    }
+    return reduxStatusInfo;
+  }, [reduxStatusInfo, rollupScenario]);
 
-  const fetchStatus = async () => {
+  const fetchRollupState = useCallback(async () => {
+    if (!batchId || STEP12_UI_FIXTURE_ENABLED) return;
     setError(null);
     try {
-      await dispatch(fetchRollupBatchStatus({ batchId })).unwrap();
+      await Promise.all([
+        dispatch(fetchRollupBatchStatus({ batchId })).unwrap(),
+        dispatch(fetchRollupBatchSources({ batchId })).unwrap(),
+      ]);
     } catch (err) {
       console.error(err);
-      setError(err?.message || "배치 상태 조회에 실패했습니다.");
+      setError(err?.message || "롤업 배치 상태 조회에 실패했습니다.");
     }
-  };
+  }, [batchId, dispatch]);
 
-  const handleCalc = async () => {
-    if (onCalculate) {
-      onCalculate(batchId);
-      return;
-    }
+  useEffect(() => {
+    let active = true;
+    Promise.resolve().then(() => {
+      if (active) fetchRollupState();
+    });
+    return () => {
+      active = false;
+    };
+  }, [fetchRollupState]);
 
-    const activeStatus = STEP12_UI_FIXTURE_ENABLED && getFixtureRollupStatus(rollupScenario) 
-      ? getFixtureRollupStatus(rollupScenario) 
-      : reduxStatusInfo;
-      
-    if (!activeStatus?.calculateReadyYn) {
-      showDefaultAlert(
-        "계산 불가",
-        "모든 자회사 데이터가 수집되지 않아 계산할 수 없습니다.",
-        "warning"
-      );
-      return;
-    }
+  if (!batchId && !STEP12_UI_FIXTURE_ENABLED) return null;
 
-    setCalculating(true);
-    try {
-      if (!STEP12_UI_FIXTURE_ENABLED) {
-        await dispatch(calculateRollupBatch({ batchId })).unwrap();
-      } else {
-        await new Promise(r => setTimeout(r, 1000));
-      }
-      showDefaultAlert("성공", "롤업 계산이 완료되었습니다.", "success");
-      fetchStatus();
-      onCalculated?.();
-    } catch (err) {
-      console.error(err);
-      showDefaultAlert("오류", err?.message || "계산에 실패했습니다.", "error");
-    } finally {
-      setCalculating(false);
-    }
-  };
-
-  const handleManageRequests = () => {
-    if (onManageRequests) {
-      onManageRequests();
-      return;
-    }
-  
-    if (STEP12_UI_FIXTURE_ENABLED) {
-      showDefaultAlert(
-        "관리",
-        "자회사 요청 관리 모달이 호출됩니다.",
-        "info"
-      );
-    }
-  };
-
-  const handleSendSource = () => {
-    if (onSendSource) {
-      onSendSource(batchId);
-      return;
-    }
-  
-    if (STEP12_UI_FIXTURE_ENABLED) {
-      showDefaultAlert(
-        "전송",
-        "지주사 전송 기능은 Backend 연결 시 구현됩니다.",
-        "info"
-      );
-    }
-  };
-
-  const statusInfo = STEP12_UI_FIXTURE_ENABLED && getFixtureRollupStatus(rollupScenario) 
-    ? getFixtureRollupStatus(rollupScenario) 
-    : reduxStatusInfo;
-
-  if (loading && !STEP12_UI_FIXTURE_ENABLED) {
+  if ((loadingStatus || loadingSources) && !statusInfo && !STEP12_UI_FIXTURE_ENABLED) {
     return (
       <div className="ob1-rollup-panel ob1-rollup-panel-v2">
-        <div className="ob1-table-loading" style={{ padding: "16px", display: 'flex', gap: '8px', alignItems: 'center' }}>
+        <div className="ob1-table-loading" style={{ padding: "16px", display: "flex", gap: "8px", alignItems: "center" }}>
           <div className="ob1-spinner" style={{ width: "20px", height: "20px" }} />
-          <p style={{ margin: 0, fontSize: "0.85rem", color: '#475569' }}>진행 중인 롤업 배치를 불러오는 중...</p>
+          <p style={{ margin: 0, fontSize: "0.85rem", color: "#475569" }}>롤업 배치 상태를 불러오고 있습니다.</p>
         </div>
       </div>
     );
   }
 
-  if (error && !STEP12_UI_FIXTURE_ENABLED) {
+  const activeError = error || statusError?.message || sourceError?.message;
+  if (activeError && !STEP12_UI_FIXTURE_ENABLED) {
     return (
       <div className="ob1-rollup-panel ob1-rollup-panel-v2">
         <div className="ob1-inline-error">
           <span className="ob1-error-icon">!</span>
-          <span>{error}</span>
-          <button type="button" className="ob1-btn-retry" onClick={fetchStatus}>
+          <span>{activeError}</span>
+          <button type="button" className="ob1-btn-retry" onClick={fetchRollupState}>
             다시 시도
           </button>
         </div>
@@ -129,74 +125,168 @@ const RollupSummaryPanel = ({ batchId, onCalculated, rollupScenario, onManageReq
 
   if (!statusInfo) return null;
 
-  const { persona, parentCompanyName, reportingYear, sendReadyYn, missingAtomicMetricIds, requestedCount = 0, sentCount = 0, pendingCount = 0, calculateReadyYn, dmaReadyYn, batchStatus } = statusInfo;
-  const isCalculated = String(batchStatus || "").toLowerCase() === "completed";
+  const requestedCount = numberOrZero(statusInfo.requestedCount);
+  const sentCount = numberOrZero(statusInfo.sentCount);
+  const pendingCount = numberOrZero(statusInfo.pendingCount);
+  const calculateReadyYn = Boolean(statusInfo.calculateReadyYn);
+  const dmaReadyYn = Boolean(statusInfo.dmaReadyYn);
+  const reportReadyYn = Boolean(statusInfo.reportReadyYn);
+  const batchStatus = String(statusInfo.batchStatus || "").toLowerCase();
+  const isCalculated = batchStatus === "completed" || batchStatus === "calculated";
+  const isCalculating = calculating || calculatingRedux;
 
-  if (persona === 'SUBSIDIARY') {
-    return (
-      <div className="ob1-rollup-panel ob1-rollup-panel-v2">
+  const handleCalc = async () => {
+    if (onCalculate) {
+      onCalculate(batchId);
+      return;
+    }
+
+    if (isCalculated) return;
+
+    if (!calculateReadyYn) {
+      showDefaultAlert(
+        "계산 대기",
+        "자회사 데이터 전송 완료 후 계산할 수 있습니다.",
+        "warning"
+      );
+      return;
+    }
+
+    setCalculating(true);
+    try {
+      if (!STEP12_UI_FIXTURE_ENABLED) {
+        await dispatch(calculateRollupBatch({ batchId })).unwrap();
+        await Promise.all([
+          dispatch(fetchRollupBatchStatus({ batchId })).unwrap(),
+          dispatch(fetchRollupBatchSources({ batchId })).unwrap(),
+        ]);
+      } else {
+        await new Promise((resolve) => setTimeout(resolve, 600));
+      }
+      showDefaultAlert("성공", "롤업 계산이 완료되었습니다.", "success");
+      onCalculated?.();
+    } catch (err) {
+      console.error(err);
+      showDefaultAlert("오류", err?.message || "롤업 계산에 실패했습니다.", "error");
+    } finally {
+      setCalculating(false);
+    }
+  };
+
+  return (
+    <div className="ob1-rollup-panel ob1-rollup-panel-v2" style={{ flexDirection: "column", alignItems: "stretch" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: "16px", width: "100%" }}>
         <div className="ob1-rollup-info">
-          <h3 className="ob1-rollup-title">지주사 데이터 전송</h3>
-          <span className="ob1-rollup-detail">요청: {parentCompanyName || 'SKM 지주사'} | 보고연도: {reportingYear || 2026}</span>
-        </div>
-        
-        <div className="ob1-rollup-stepper" style={{ flex: 1, margin: '0 24px', justifyContent: 'center' }}>
-          <div className="ob1-rollup-step completed">요청 수신</div>
-          <div className={`ob1-rollup-step ${sendReadyYn ? 'completed' : 'active'}`}>데이터 입력</div>
-          <div className={`ob1-rollup-step ${!sendReadyYn ? '' : 'active'}`}>승인 대기</div>
-          <div className="ob1-rollup-step">전송 완료</div>
+          <h3 className="ob1-rollup-title">자회사 데이터 롤업</h3>
+          <span className="ob1-rollup-detail">
+            Batch #{statusInfo.batchId || batchId} · {purposeLabel(statusInfo.rollupPurposeCode || rollupPurposeCode)}
+            {metricScopeCode ? ` · ${statusInfo.metricScopeCode || metricScopeCode}` : ""}
+          </span>
         </div>
 
-        <div className="ob1-rollup-actions" style={{ display: 'flex', alignItems: 'center' }}>
-          {!sendReadyYn && missingAtomicMetricIds?.length > 0 && (
-             <span style={{ fontSize: '0.75rem', color: '#ef4444', marginRight: '12px', fontWeight: 600 }}>누락: {missingAtomicMetricIds.length}건</span>
-          )}
+        <div className="ob1-rollup-stepper" style={{ flex: 1, margin: "0 24px", justifyContent: "center" }}>
+          <div className="ob1-rollup-step completed">요청 생성</div>
+          <div className={`ob1-rollup-step ${calculateReadyYn ? "completed" : "active"}`}>자회사 전송</div>
+          <div className={`ob1-rollup-step ${isCalculated ? "completed" : calculateReadyYn ? "active" : ""}`}>Rollup 계산</div>
+          <div className={`ob1-rollup-step ${dmaReadyYn || reportReadyYn ? "completed" : ""}`}>
+            {rollupPurposeCode === "REPORT_DISCLOSURE" ? "보고서 준비" : "DMA 준비"}
+          </div>
+        </div>
+
+        <div className="ob1-rollup-actions" style={{ display: "flex", alignItems: "center" }}>
           <button
-            className={`ob1-rollup-btn ${sendReadyYn ? 'primary' : ''}`}
-            onClick={handleSendSource}
-            disabled={!sendReadyYn}
-            title={!sendReadyYn ? "필수값이 누락되어 전송할 수 없습니다." : ""}
+            type="button"
+            className="ob1-rollup-btn secondary"
+            onClick={() => setShowSources((prev) => !prev)}
+            style={{ marginRight: "8px" }}
           >
-            지주사에 전송
+            요청 관리
+          </button>
+          <button
+            type="button"
+            className={`ob1-rollup-btn ${isCalculated ? "calculated" : calculateReadyYn ? "primary" : ""}`}
+            onClick={handleCalc}
+            disabled={isCalculating || !calculateReadyYn || isCalculated}
+            title={!calculateReadyYn ? "자회사 데이터 전송 완료 후 계산할 수 있습니다." : ""}
+          >
+            {isCalculating ? "계산 중..." : isCalculated ? "Rollup 계산 완료" : calculateReadyYn ? "Rollup 계산 실행" : "자회사 데이터 대기"}
           </button>
         </div>
       </div>
-    );
-  }
 
-  const progressPercent = requestedCount > 0 ? Math.round((sentCount / requestedCount) * 100) : 0;
-  
-  return (
-    <div className="ob1-rollup-panel ob1-rollup-panel-v2">
-      <div className="ob1-rollup-info">
-        <h3 className="ob1-rollup-title">자회사 데이터 롤업</h3>
-        <span className="ob1-rollup-detail">수집 현황: {sentCount} / {requestedCount}개사 완료</span>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(5, minmax(0, 1fr))", gap: "8px", marginTop: "14px" }}>
+        {[
+          ["요청", requestedCount],
+          ["전송", sentCount],
+          ["대기", pendingCount],
+          ["계산 가능", calculateReadyYn ? "Y" : "N"],
+          ["상태", statusInfo.batchStatus || "-"],
+        ].map(([label, value]) => (
+          <div key={label} style={{ padding: "10px 12px", border: "1px solid #e2e8f0", borderRadius: "8px", background: "#fff" }}>
+            <div style={{ fontSize: "0.75rem", color: "#64748b", marginBottom: "4px" }}>{label}</div>
+            <div style={{ fontWeight: 700, color: "#0f172a" }}>{value}</div>
+          </div>
+        ))}
       </div>
 
-      <div className="ob1-rollup-stepper" style={{ flex: 1, margin: '0 24px', justifyContent: 'center' }}>
-        <div className="ob1-rollup-step completed">수집 시작</div>
-        <div className={`ob1-rollup-step ${calculateReadyYn ? 'completed' : 'active'}`}>전송 대기</div>
-        <div className={`ob1-rollup-step ${isCalculated ? 'completed' : (calculateReadyYn ? 'active' : '')}`}>롤업 계산</div>
-        <div className={`ob1-rollup-step ${dmaReadyYn ? 'completed' : ''}`}>DMA 준비 완료</div>
-      </div>
+      {!calculateReadyYn && !isCalculated && (
+        <div style={{ marginTop: "10px", fontSize: "0.82rem", color: "#64748b" }}>
+          자회사 데이터 전송 완료 후 계산할 수 있습니다.
+        </div>
+      )}
 
-      <div className="ob1-rollup-actions" style={{ display: 'flex', alignItems: 'center' }}>
-        <button
-          className="ob1-rollup-btn secondary"
-          onClick={handleManageRequests}
-          style={{ marginRight: '8px' }}
-        >
-          요청 관리
-        </button>
-        <button
-          className={`ob1-rollup-btn ${isCalculated ? "calculated" : (calculateReadyYn ? "primary" : "")}`}
-          onClick={handleCalc}
-          disabled={calculating || !calculateReadyYn || isCalculated}
-          title={!calculateReadyYn ? "모든 자회사 데이터가 수집되어야 계산 가능합니다." : ""}
-        >
-          {calculating ? "계산 중..." : isCalculated ? "계산 완료" : "롤업 계산 실행"}
-        </button>
-      </div>
+      {showSources && (
+        <div style={{ marginTop: "16px", borderTop: "1px solid #e2e8f0", paddingTop: "12px", width: "100%" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "8px" }}>
+            <strong style={{ color: "#0f172a" }}>자회사 전송 현황</strong>
+            {(loadingSources || loadingStatus) && <span style={{ fontSize: "0.8rem", color: "#64748b" }}>갱신 중...</span>}
+          </div>
+          {batchSources.length === 0 ? (
+            <div style={{ padding: "18px", border: "1px dashed #cbd5e1", borderRadius: "8px", color: "#64748b", textAlign: "center" }}>
+              표시할 자회사 전송 현황이 없습니다.
+            </div>
+          ) : (
+            <div className="ob1-table-container" style={{ maxHeight: "260px", overflow: "auto" }}>
+              <table className="ob1-table">
+                <thead>
+                  <tr>
+                    <th>자회사</th>
+                    <th>준비 상태</th>
+                    <th>승인 상태</th>
+                    <th>전송 상태</th>
+                    <th>승인 Atomic</th>
+                    <th>누락</th>
+                    <th>전송/수신</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {batchSources.map((source) => {
+                    const required = source.requiredAtomicCount ?? source.requiredCount ?? 0;
+                    const approved = source.currentApprovedAtomicCount ?? source.approvedAtomicCount ?? 0;
+                    const missing = source.currentMissingAtomicCount ?? source.missingAtomicCount ?? source.missingAtomicMetricIds?.length ?? 0;
+                    return (
+                      <tr key={source.sourceCompanyId || source.companyId}>
+                        <td>{source.sourceCompanyName || source.companyName || source.sourceCompanyId || source.companyId}</td>
+                        <td>{readinessLabel(source.readinessStatus)}</td>
+                        <td>{approvalLabel(source.approvalStatus)}</td>
+                        <td>{transferLabel(source.transferStatus)}</td>
+                        <td>{approved} / {required}</td>
+                        <td>{missing}</td>
+                        <td>
+                          <div style={{ display: "flex", flexDirection: "column", gap: "2px", fontSize: "0.78rem" }}>
+                            <span>전송: {source.sentAt || "-"}</span>
+                            <span>수신: {source.receivedAt || "-"}</span>
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/homes/onboards/modal/SubsidiaryRequestModal.jsx
+++ b/frontend/src/homes/onboards/modal/SubsidiaryRequestModal.jsx
@@ -1,50 +1,113 @@
-import { useState, useEffect } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { useDispatch, useSelector } from "react-redux";
 import {
   createRollupBatch,
+  fetchRollupBatchSources,
+  fetchRollupBatchStatus,
+  fetchRollupScopePreview,
   fetchRollupSubsidiaries,
+  setActiveBatchId,
 } from "@stores/reportSlice";
 import { showDefaultAlert } from "@components/UI/ServiceAlert";
 
-/**
- * SubsidiaryRequestModal
- *
- * G0 데이터 요청 자회사 선택 modal.
- * DTO: res.data.items -> { companyId, companyCode, companyName }
- */
-const SubsidiaryRequestModal = ({ isOpen, onClose, runId, onRequested }) => {
+const purposeLabel = (code) => {
+  const value = String(code || "").toUpperCase();
+  if (value === "REPORT_DISCLOSURE") return "보고서 연결 공시";
+  if (value === "DMA_PRECHECK") return "DMA 사전 계산";
+  return value || "-";
+};
+
+const asItems = (value) => {
+  if (Array.isArray(value)) return value;
+  if (Array.isArray(value?.items)) return value.items;
+  if (Array.isArray(value?.metricItems)) return value.metricItems;
+  if (Array.isArray(value?.metrics)) return value.metrics;
+  return [];
+};
+
+const SubsidiaryRequestModal = ({
+  isOpen,
+  onClose,
+  runId,
+  reportingYear,
+  sourceCycleId,
+  rollupPurposeCode = "DMA_PRECHECK",
+  metricScopeCode = "G0_02_FINANCIAL_BASIS",
+  onRequested,
+}) => {
   const dispatch = useDispatch();
   const subsidiaries = useSelector((state) => state.report.rollup.subsidiaries);
-  const loading = useSelector((state) => state.report.loading.subsidiaries);
+  const scopePreview = useSelector((state) => state.report.rollup.scopePreview);
+  const loadingSubsidiaries = useSelector((state) => state.report.loading.subsidiaries);
+  const loadingPreview = useSelector((state) => state.report.loading.rollupScopePreview);
+  const creatingBatch = useSelector((state) => state.report.loading.createBatch);
   const [selectedIds, setSelectedIds] = useState([]);
   const [requesting, setRequesting] = useState(false);
   const [error, setError] = useState(null);
 
-  useEffect(() => {
-    if (isOpen) {
-      loadSubsidiaries();
-    } else {
-      setSelectedIds([]);
-      setError(null);
-    }
-  }, [isOpen]);
+  const requiresSourceCycle = rollupPurposeCode === "REPORT_DISCLOSURE";
+  const previewMetricItems = useMemo(() => asItems(scopePreview), [scopePreview]);
+  const metricCount =
+    scopePreview?.metricCount ??
+    scopePreview?.requestedMetricCount ??
+    previewMetricItems.length;
+  const atomicCount =
+    scopePreview?.atomicCount ??
+    scopePreview?.requiredAtomicCount ??
+    scopePreview?.resolvedExternalEntityAtomicCount ??
+    previewMetricItems.reduce((sum, metric) => sum + (metric.atomicCount || metric.atomicItems?.length || 0), 0);
 
-  const loadSubsidiaries = async () => {
+  const loadData = useCallback(async () => {
+    if (!isOpen) return;
+    if (requiresSourceCycle && !sourceCycleId) {
+      setError("POST DMA 공시 롤업은 sourceCycleId가 필요합니다.");
+      return;
+    }
+
     setError(null);
     try {
-      const res = await dispatch(fetchRollupSubsidiaries({ runId })).unwrap();
-      const items = Array.isArray(res?.data?.items)
-        ? res.data.items
-        : Array.isArray(res?.data)
-          ? res.data
-          : [];
-      setSelectedIds(items.map((item) => item.companyId));
+      const commonParams = {
+        runId,
+        sourceCycleId,
+        rollupPurposeCode,
+        metricScopeCode,
+      };
+
+      const [, subsidiaryRes] = await Promise.all([
+        dispatch(fetchRollupScopePreview(commonParams)).unwrap(),
+        dispatch(fetchRollupSubsidiaries(commonParams)).unwrap(),
+      ]);
+
+      const items = Array.isArray(subsidiaryRes?.data?.items)
+        ? subsidiaryRes.data.items
+        : Array.isArray(subsidiaryRes?.items)
+          ? subsidiaryRes.items
+          : Array.isArray(subsidiaryRes?.data)
+            ? subsidiaryRes.data
+            : [];
+      setSelectedIds(items.map((item) => item.companyId).filter((id) => id != null));
     } catch (err) {
       console.error(err);
-      setError(err?.message || "자회사 목록 조회에 실패했습니다.");
+      setError(err?.message || "자회사 요청 정보 조회에 실패했습니다.");
     }
-  };
+  }, [dispatch, isOpen, metricScopeCode, requiresSourceCycle, rollupPurposeCode, runId, sourceCycleId]);
+
+  useEffect(() => {
+    let active = true;
+    Promise.resolve().then(() => {
+      if (!active) return;
+      if (isOpen) {
+        loadData();
+      } else {
+        setSelectedIds([]);
+        setError(null);
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, [isOpen, loadData]);
 
   const handleToggle = (companyId) => {
     setSelectedIds((prev) =>
@@ -56,16 +119,35 @@ const SubsidiaryRequestModal = ({ isOpen, onClose, runId, onRequested }) => {
 
   const handleRequest = async () => {
     if (selectedIds.length === 0) return;
+    if (requiresSourceCycle && !sourceCycleId) {
+      showDefaultAlert("요청 불가", "POST DMA 공시 롤업은 sourceCycleId가 필요합니다.", "warning");
+      return;
+    }
 
     setRequesting(true);
     try {
-      const res = await dispatch(createRollupBatch({
-        runId,
-        sourceCompanyIds: selectedIds,
-      })).unwrap();
+      const res = await dispatch(
+        createRollupBatch({
+          runId,
+          sourceCycleId,
+          sourceCompanyIds: selectedIds,
+          rollupPurposeCode,
+          metricScopeCode,
+        })
+      ).unwrap();
+
+      const data = res?.data || res;
+      const batchId = data?.batchId;
+      if (batchId) {
+        dispatch(setActiveBatchId(batchId));
+        await Promise.all([
+          dispatch(fetchRollupBatchStatus({ batchId })).unwrap(),
+          dispatch(fetchRollupBatchSources({ batchId })).unwrap(),
+        ]);
+      }
 
       showDefaultAlert("완료", "자회사 데이터 요청이 완료되었습니다.", "success");
-      onRequested?.(res.data || res);
+      onRequested?.(batchId);
       onClose();
     } catch (err) {
       console.error(err);
@@ -74,33 +156,76 @@ const SubsidiaryRequestModal = ({ isOpen, onClose, runId, onRequested }) => {
       setRequesting(false);
     }
   };
+
   if (!isOpen) return null;
+
+  const loading = loadingSubsidiaries || loadingPreview;
+  const disabled =
+    loading ||
+    requesting ||
+    creatingBatch ||
+    Boolean(error) ||
+    selectedIds.length === 0 ||
+    (requiresSourceCycle && !sourceCycleId);
 
   return createPortal(
     <div className="ob1-modal-overlay">
-      <div className="ob1-modal-content" style={{ width: 480 }}>
+      <div className="ob1-modal-content" style={{ width: 760 }}>
         <div className="ob1-modal-header">
-          <h2>G0 데이터 요청 자회사 선택</h2>
+          <h2>자회사 데이터 요청</h2>
           <button className="ob1-btn-close" onClick={onClose}>×</button>
         </div>
         <div className="ob1-modal-body">
-          <p style={{ marginBottom: 16, fontSize: "0.9rem", color: "#475569" }}>
-            데이터를 수집할 자회사를 선택해 주세요.
-          </p>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(4, minmax(0, 1fr))", gap: "8px", marginBottom: "16px" }}>
+            {[
+              ["보고연도", reportingYear || "-"],
+              ["롤업 목적", purposeLabel(rollupPurposeCode)],
+              ["Metric", metricCount || 0],
+              ["Atomic", atomicCount || 0],
+            ].map(([label, value]) => (
+              <div key={label} style={{ padding: "10px 12px", border: "1px solid #e2e8f0", borderRadius: "8px", background: "#f8fafc" }}>
+                <div style={{ fontSize: "0.75rem", color: "#64748b", marginBottom: "4px" }}>{label}</div>
+                <div style={{ fontWeight: 700, color: "#0f172a" }}>{value}</div>
+              </div>
+            ))}
+          </div>
 
-          {/* loading */}
+          <div style={{ marginBottom: "16px" }}>
+            <div style={{ fontWeight: 700, marginBottom: "8px", color: "#0f172a" }}>요청 Metric 미리보기</div>
+            {loadingPreview && !scopePreview ? (
+              <div style={{ padding: "14px", color: "#64748b", border: "1px dashed #cbd5e1", borderRadius: "8px" }}>
+                롤업 범위를 확인하고 있습니다.
+              </div>
+            ) : previewMetricItems.length === 0 ? (
+              <div style={{ padding: "14px", color: "#64748b", border: "1px dashed #cbd5e1", borderRadius: "8px" }}>
+                표시할 Metric 미리보기가 없습니다.
+              </div>
+            ) : (
+              <div style={{ maxHeight: "132px", overflow: "auto", display: "grid", gridTemplateColumns: "repeat(2, minmax(0, 1fr))", gap: "8px" }}>
+                {previewMetricItems.map((metric) => (
+                  <div key={metric.metricId} style={{ padding: "10px", border: "1px solid #e2e8f0", borderRadius: "8px" }}>
+                    <div style={{ fontWeight: 700, color: "#1e293b" }}>{metric.metricId}</div>
+                    <div style={{ fontSize: "0.8rem", color: "#64748b", marginTop: "2px" }}>
+                      {metric.metricName || metric.metricNameKr || "-"}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
           {loading && subsidiaries.length === 0 && (
             <div className="ob1-table-loading" style={{ padding: "24px" }}>
               <div className="ob1-spinner" />
-              <p>자회사 목록을 불러오고 있습니다...</p>
+              <p>자회사 목록을 불러오고 있습니다.</p>
             </div>
           )}
 
           {!loading && error && (
-            <div className="ob1-inline-error" style={{ margin: "24px" }}>
+            <div className="ob1-inline-error" style={{ margin: "16px 0" }}>
               <span className="ob1-error-icon">!</span>
               <span>{error}</span>
-              <button type="button" className="ob1-btn-retry" onClick={loadSubsidiaries}>
+              <button type="button" className="ob1-btn-retry" onClick={loadData}>
                 다시 시도
               </button>
             </div>
@@ -108,11 +233,11 @@ const SubsidiaryRequestModal = ({ isOpen, onClose, runId, onRequested }) => {
 
           {!loading && !error && subsidiaries.length === 0 && (
             <div style={{ padding: "24px", textAlign: "center", color: "#64748b" }}>
-              등록된 자회사가 없습니다.
+              요청 가능한 자회사가 없습니다.
             </div>
           )}
 
-          {((loading && subsidiaries.length > 0) || (!loading && !error && subsidiaries.length > 0)) && (
+          {subsidiaries.length > 0 && (
             <ul
               className="sub-list"
               style={{
@@ -122,6 +247,8 @@ const SubsidiaryRequestModal = ({ isOpen, onClose, runId, onRequested }) => {
                 display: "flex",
                 flexDirection: "column",
                 gap: "8px",
+                maxHeight: "260px",
+                overflow: "auto",
               }}
             >
               {subsidiaries.map((sub) => (
@@ -150,19 +277,15 @@ const SubsidiaryRequestModal = ({ isOpen, onClose, runId, onRequested }) => {
                       checked={selectedIds.includes(sub.companyId)}
                       onChange={() => handleToggle(sub.companyId)}
                     />
-                    <span style={{ fontWeight: 500 }}>
-                      {sub.companyName}
-                    </span>
+                    <span style={{ fontWeight: 500 }}>{sub.companyName}</span>
                     {sub.companyCode && (
                       <span style={{ fontSize: "0.8rem", color: "#94a3b8" }}>
                         ({sub.companyCode})
                       </span>
                     )}
                   </label>
-                  <div style={{ textAlign: "right", fontSize: "0.8rem" }}>
-                    <span style={{ color: "#2563eb" }}>
-                      요청 대상
-                    </span>
+                  <div style={{ textAlign: "right", fontSize: "0.8rem", color: "#2563eb" }}>
+                    요청 대상
                   </div>
                 </li>
               ))}
@@ -198,13 +321,13 @@ const SubsidiaryRequestModal = ({ isOpen, onClose, runId, onRequested }) => {
               color: "#fff",
               border: "none",
               borderRadius: "4px",
-              cursor: selectedIds.length ? "pointer" : "not-allowed",
-              opacity: selectedIds.length ? 1 : 0.5,
+              cursor: disabled ? "not-allowed" : "pointer",
+              opacity: disabled ? 0.5 : 1,
             }}
             onClick={handleRequest}
-            disabled={!selectedIds.length || requesting}
+            disabled={disabled}
           >
-            {requesting ? "요청 중..." : "요청 보내기"}
+            {requesting || creatingBatch ? "요청 중..." : "요청 보내기"}
           </button>
         </div>
       </div>
@@ -214,5 +337,3 @@ const SubsidiaryRequestModal = ({ isOpen, onClose, runId, onRequested }) => {
 };
 
 export default SubsidiaryRequestModal;
-
-

--- a/frontend/src/homes/onboards/modal/SubsidiaryRequestModal.jsx
+++ b/frontend/src/homes/onboards/modal/SubsidiaryRequestModal.jsx
@@ -47,7 +47,18 @@ const SubsidiaryRequestModal = ({
   const [error, setError] = useState(null);
 
   const requiresSourceCycle = rollupPurposeCode === "REPORT_DISCLOSURE";
-  const previewMetricItems = useMemo(() => asItems(scopePreview), [scopePreview]);
+  const previewMetricItems = useMemo(() => {
+    const items = asItems(scopePreview);
+    if (items.length > 0) return items;
+
+    if (Array.isArray(scopePreview?.metricIds)) {
+      return scopePreview.metricIds.map((metricId) => ({
+        metricId,
+      }));
+    }
+
+    return [];
+  }, [scopePreview]);
   const metricCount =
     scopePreview?.metricCount ??
     scopePreview?.requestedMetricCount ??
@@ -56,6 +67,7 @@ const SubsidiaryRequestModal = ({
     scopePreview?.atomicCount ??
     scopePreview?.requiredAtomicCount ??
     scopePreview?.resolvedExternalEntityAtomicCount ??
+    scopePreview?.requiredAtomicMetricIds?.length ??
     previewMetricItems.reduce((sum, metric) => sum + (metric.atomicCount || metric.atomicItems?.length || 0), 0);
 
   const loadData = useCallback(async () => {

--- a/frontend/src/homes/onboards/modal/SubsidiaryTransferModal.jsx
+++ b/frontend/src/homes/onboards/modal/SubsidiaryTransferModal.jsx
@@ -1,72 +1,212 @@
-import { useState, useEffect } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { useDispatch, useSelector } from "react-redux";
 import {
+  fetchRollupRequestDetail,
   fetchRollupRequests,
   sendRollupSource,
 } from "@stores/reportSlice";
-import { showDefaultAlert, showConfirmAlert } from "@components/UI/ServiceAlert";
+import { showConfirmAlert, showDefaultAlert } from "@components/UI/ServiceAlert";
 
-/**
- * SubsidiaryTransferModal
- *
- * 지주사 데이터 전송 modal.
- * DTO: res.data.items -> {
- *   batchId, parentCompanyName, reportingYear,
- *   metricScopeCode, sendReadyYn, missingAtomicMetricIds
- * }
- * sendReadyYn=false 이면 전송 비활성화
- */
-const SubsidiaryTransferModal = ({ isOpen, onClose, onTransferred }) => {
+const readinessLabel = (status) => {
+  const value = String(status || "").toUpperCase();
+  if (value === "READY") return "전송 가능";
+  if (value === "PARTIAL") return "입력 진행중";
+  if (value === "NOT_STARTED") return "미입력";
+  return status || "-";
+};
+
+const transferLabel = (status) => {
+  const value = String(status || "").toLowerCase();
+  if (value === "received") return "수신 완료";
+  if (value === "sent") return "전송 완료";
+  if (value === "not_sent") return "미전송";
+  return status || "-";
+};
+
+const approvalLabel = (status) => {
+  const value = String(status || "").toLowerCase();
+  if (value === "approved") return "승인 완료";
+  if (value === "reviewed") return "검토 완료";
+  if (value === "rejected") return "반려";
+  if (value === "pending" || value === "submitted") return "승인 대기";
+  return status || "-";
+};
+
+const purposeLabel = (code) => {
+  const value = String(code || "").toUpperCase();
+  if (value === "REPORT_DISCLOSURE") return "보고서 연결 공시";
+  if (value === "DMA_PRECHECK") return "DMA 사전 계산";
+  return value || "-";
+};
+
+const metricMissingCount = (item = {}) =>
+  item.currentMissingAtomicCount ??
+  item.missingAtomicCount ??
+  item.missingAtomicMetricIds?.length ??
+  0;
+
+const metricApprovedCount = (item = {}) =>
+  item.currentApprovedAtomicCount ?? item.approvedAtomicCount ?? 0;
+
+const MetricReadinessList = ({ title, description, items = [] }) => (
+  <div style={{ marginTop: "14px" }}>
+    <div style={{ display: "flex", alignItems: "baseline", gap: "8px", marginBottom: "8px" }}>
+      <strong style={{ color: "#0f172a" }}>{title}</strong>
+      {description && <span style={{ fontSize: "0.78rem", color: "#64748b" }}>{description}</span>}
+    </div>
+    {items.length === 0 ? (
+      <div style={{ padding: "12px", border: "1px dashed #cbd5e1", borderRadius: "8px", color: "#64748b" }}>
+        표시할 항목이 없습니다.
+      </div>
+    ) : (
+      <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+        {items.map((item) => {
+          const missing = item.missingAtomicMetricIds || [];
+          return (
+            <div key={item.metricId} style={{ border: "1px solid #e2e8f0", borderRadius: "8px", padding: "10px" }}>
+              <div style={{ display: "flex", justifyContent: "space-between", gap: "8px" }}>
+                <div>
+                  <div style={{ fontWeight: 700, color: "#1e293b" }}>{item.metricId}</div>
+                  <div style={{ fontSize: "0.8rem", color: "#64748b", marginTop: "2px" }}>
+                    {item.metricName || item.metricNameKr || "-"}
+                  </div>
+                </div>
+                <div style={{ fontSize: "0.82rem", color: "#475569", textAlign: "right" }}>
+                  승인 {metricApprovedCount(item)} / 필요 {item.requiredAtomicCount ?? item.requiredCount ?? 0}
+                  <br />
+                  누락 {metricMissingCount(item)}
+                </div>
+              </div>
+              {missing.length > 0 && (
+                <div style={{ marginTop: "6px", fontSize: "0.78rem", color: "#b45309" }}>
+                  누락 Atomic: {missing.join(", ")}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    )}
+  </div>
+);
+
+const SubsidiaryTransferModal = ({
+  isOpen,
+  onClose,
+  onTransferred,
+  onNavigateToInput,
+  reportingYear,
+}) => {
   const dispatch = useDispatch();
   const requests = useSelector((state) => state.report.rollup.requests);
-  const loading = useSelector((state) => state.report.loading.requests);
+  const requestDetail = useSelector((state) => state.report.rollup.selectedRequestDetail);
+  const loadingRequests = useSelector((state) => state.report.loading.requests);
+  const loadingDetail = useSelector((state) => state.report.loading.rollupRequestDetail);
+  const sendingSource = useSelector((state) => state.report.loading.sendSource);
+  const requestError = useSelector((state) => state.report.error.requests);
+  const detailError = useSelector((state) => state.report.error.rollupRequestDetail);
   const [sending, setSending] = useState(false);
   const [selectedBatchId, setSelectedBatchId] = useState(null);
   const [error, setError] = useState(null);
 
-  useEffect(() => {
-    if (isOpen) {
-      loadRequests();
-    } else {
-      setSelectedBatchId(null);
-      setError(null);
-    }
-  }, [isOpen]);
-
-  const loadRequests = async () => {
+  const loadRequests = useCallback(async () => {
     setError(null);
     try {
-      await dispatch(fetchRollupRequests({ allPurposesYn: true })).unwrap();
+      await dispatch(fetchRollupRequests({ includeSentYn: true, allPurposesYn: true })).unwrap();
     } catch (err) {
       console.error(err);
       setError(err?.message || "요청 목록 조회에 실패했습니다.");
     }
+  }, [dispatch]);
+
+  const loadDetail = useCallback(async (batchId) => {
+    if (!batchId) return;
+    setError(null);
+    try {
+      await dispatch(fetchRollupRequestDetail({ batchId })).unwrap();
+    } catch (err) {
+      console.error(err);
+      setError(err?.message || "요청 상세 조회에 실패했습니다.");
+    }
+  }, [dispatch]);
+
+  useEffect(() => {
+    let active = true;
+    Promise.resolve().then(() => {
+      if (!active) return;
+      if (isOpen) {
+        loadRequests();
+      } else {
+        setSelectedBatchId(null);
+        setError(null);
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, [isOpen, loadRequests]);
+
+  const selectedRequest = useMemo(
+    () => requests.find((request) => request.batchId === selectedBatchId),
+    [requests, selectedBatchId]
+  );
+
+  const activeDetail = requestDetail?.batchId === selectedBatchId ? requestDetail : null;
+  const activeRequest = activeDetail || selectedRequest || {};
+  const transferStatus = String(activeRequest.transferStatus || "").toLowerCase();
+  const isTransferred = transferStatus === "sent" || transferStatus === "received";
+  const currentMissingAtomicCount =
+    activeRequest.currentMissingAtomicCount ??
+    activeRequest.missingAtomicCount ??
+    activeRequest.missingAtomicMetricIds?.length ??
+    0;
+  const sendReadyYn = activeRequest.sendReadyYn === true;
+  const inputWorkspace = activeDetail?.inputWorkspace || activeRequest.inputWorkspace || {};
+  const actionableInputMetricIds = inputWorkspace.actionableInputMetricIds || activeDetail?.actionableInputMetricIds || [];
+  const canSend = selectedBatchId && sendReadyYn && !isTransferred && !sending && !sendingSource;
+  const canNavigateToInput =
+    selectedBatchId &&
+    currentMissingAtomicCount > 0 &&
+    inputWorkspace.availableYn === true;
+
+  const handleSelectBatch = (batchId) => {
+    setSelectedBatchId(batchId);
+    loadDetail(batchId);
   };
 
-  const selectedRequest = requests.find((r) => r.batchId === selectedBatchId);
-  const canSend =
-    selectedBatchId &&
-    selectedRequest?.sendReadyYn !== false &&
-    !sending;
+  const handleNavigateInput = () => {
+    if (!canNavigateToInput) return;
+    const targetYear =
+      inputWorkspace.reportingYear ||
+      activeDetail?.reportingYear ||
+      selectedRequest?.reportingYear ||
+      reportingYear;
+    const targetCycleType =
+      inputWorkspace.cycleType ||
+      activeDetail?.inputCycleType ||
+      activeDetail?.cycleType ||
+      "POST_DMA_DISCLOSURE";
+    const metricId = actionableInputMetricIds[0] || activeDetail?.requestedMetricIds?.[0] || activeDetail?.metricIds?.[0];
+    const params = new URLSearchParams({
+      reportingYear: String(targetYear),
+      cycleType: targetCycleType,
+    });
+    if (metricId) params.set("metricId", metricId);
+    onNavigateToInput?.({
+      url: `/onb?${params.toString()}`,
+      reportingYear: targetYear,
+      cycleType: targetCycleType,
+      metricId,
+    });
+  };
 
   const handleSend = async () => {
-    if (!selectedBatchId) return;
-
-    /* sendReadyYn 체크 */
-    if (selectedRequest?.sendReadyYn === false) {
-      const missing = selectedRequest.missingAtomicMetricIds || [];
-      showDefaultAlert(
-        "전송 불가",
-        `필수 입력 항목이 누락되어 전송할 수 없습니다.${missing.length > 0 ? `\n누락 항목: ${missing.join(", ")}` : ""}`,
-        "warning"
-      );
-      return;
-    }
+    if (!selectedBatchId || !canSend) return;
 
     const confirm = await showConfirmAlert(
       "데이터 전송",
-      "현재까지 입력/승인된 G0 데이터를 지주사로 전송하시겠습니까?",
+      "현재 승인 완료된 데이터를 지주사로 전송하시겠습니까?",
       "question"
     );
     if (!confirm) return;
@@ -74,9 +214,12 @@ const SubsidiaryTransferModal = ({ isOpen, onClose, onTransferred }) => {
     setSending(true);
     try {
       await dispatch(sendRollupSource({ batchId: selectedBatchId })).unwrap();
+      await Promise.all([
+        dispatch(fetchRollupRequests({ includeSentYn: true, allPurposesYn: true })).unwrap(),
+        dispatch(fetchRollupRequestDetail({ batchId: selectedBatchId })).unwrap(),
+      ]);
       showDefaultAlert("전송 완료", "지주사로 데이터 전송이 완료되었습니다.", "success");
       onTransferred?.(selectedBatchId);
-      onClose();
     } catch (err) {
       console.error(err);
       showDefaultAlert("오류", err?.message || "데이터 전송에 실패했습니다.", "error");
@@ -84,101 +227,144 @@ const SubsidiaryTransferModal = ({ isOpen, onClose, onTransferred }) => {
       setSending(false);
     }
   };
+
   if (!isOpen) return null;
+
+  const activeError = error || requestError?.message || detailError?.message;
 
   return createPortal(
     <div className="ob1-modal-overlay">
-      <div className="ob1-modal-content" style={{ width: 500 }}>
+      <div className="ob1-modal-content" style={{ width: 920 }}>
         <div className="ob1-modal-header">
           <h2>지주사 데이터 전송 요청 확인</h2>
           <button className="ob1-btn-close" onClick={onClose}>×</button>
         </div>
         <div className="ob1-modal-body">
           <p style={{ marginBottom: 16, fontSize: "0.9rem", color: "#475569" }}>
-            지주사에서 접수한 데이터 요청 목록입니다. 전송할 요청을 선택해 주세요.
+            지주사에서 접수한 데이터 요청을 확인하고 전송할 수 있습니다.
           </p>
 
-          {/* loading */}
-          {loading && requests.length === 0 && (
+          {loadingRequests && requests.length === 0 && (
             <div className="ob1-table-loading" style={{ padding: "24px" }}>
               <div className="ob1-spinner" />
-              <p>요청 목록을 불러오고 있습니다...</p>
+              <p>요청 목록을 불러오고 있습니다.</p>
             </div>
           )}
 
-          {/* error */}
-          {!loading && error && (
+          {activeError && (
             <div className="ob1-inline-error" style={{ margin: "16px 0" }}>
               <span className="ob1-error-icon">!</span>
-              <span>{error}</span>
+              <span>{activeError}</span>
               <button type="button" className="ob1-btn-retry" onClick={loadRequests}>
                 다시 시도
               </button>
             </div>
           )}
 
-          {/* empty */}
-          {!loading && !error && requests.length === 0 && (
+          {!loadingRequests && !activeError && requests.length === 0 && (
             <div style={{ padding: "24px", textAlign: "center", color: "#64748b" }}>
               대기 중인 요청이 없습니다.
             </div>
           )}
 
-          {/* list */}
-          {((loading && requests.length > 0) || (!loading && !error && requests.length > 0)) && (
-            <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
-              {requests.map((req) => {
-                const isNotReady = req.sendReadyYn === false;
-                return (
-                  <label
-                    key={req.batchId}
-                    style={{
-                      display: "flex",
-                      alignItems: "flex-start",
-                      gap: "12px",
-                      padding: "16px",
-                      border: `1px solid ${selectedBatchId === req.batchId ? "#3b82f6" : "#e2e8f0"}`,
-                      borderRadius: "8px",
-                      cursor: isNotReady ? "not-allowed" : "pointer",
-                      background: selectedBatchId === req.batchId
-                        ? "#eff6ff"
-                        : isNotReady
-                          ? "#fefce8"
-                          : "#fff",
-                      opacity: isNotReady ? 0.8 : 1,
-                    }}
-                  >
-                    <input
-                      type="radio"
-                      name="requestBatch"
-                      value={req.batchId}
-                      checked={selectedBatchId === req.batchId}
-                      onChange={() => setSelectedBatchId(req.batchId)}
-                      disabled={isNotReady}
-                      style={{ marginTop: "4px" }}
+          {requests.length > 0 && (
+            <div style={{ display: "grid", gridTemplateColumns: "300px minmax(0, 1fr)", gap: "16px" }}>
+              <div style={{ display: "flex", flexDirection: "column", gap: "10px", maxHeight: "560px", overflow: "auto" }}>
+                {requests.map((req) => {
+                  const missing = req.currentMissingAtomicCount ?? req.missingAtomicCount ?? req.missingAtomicMetricIds?.length ?? 0;
+                  return (
+                    <button
+                      key={req.batchId}
+                      type="button"
+                      onClick={() => handleSelectBatch(req.batchId)}
+                      style={{
+                        textAlign: "left",
+                        padding: "14px",
+                        border: `1px solid ${selectedBatchId === req.batchId ? "#3b82f6" : "#e2e8f0"}`,
+                        borderRadius: "8px",
+                        cursor: "pointer",
+                        background: selectedBatchId === req.batchId ? "#eff6ff" : "#fff",
+                      }}
+                    >
+                      <div style={{ fontWeight: 700, color: "#1e293b" }}>
+                        Batch #{req.batchId}
+                      </div>
+                      <div style={{ fontSize: "0.82rem", color: "#64748b", marginTop: "4px" }}>
+                        {req.parentCompanyName || "지주사 요청"} · {req.reportingYear || "-"}
+                      </div>
+                      <div style={{ fontSize: "0.78rem", color: "#64748b", marginTop: "4px" }}>
+                        {purposeLabel(req.rollupPurposeCode)} · {req.metricScopeCode || "-"}
+                      </div>
+                      <div style={{ display: "flex", gap: "6px", flexWrap: "wrap", marginTop: "8px" }}>
+                        <span className="ob1-status-pill">{readinessLabel(req.readinessStatus)}</span>
+                        <span className="ob1-status-pill">{transferLabel(req.transferStatus)}</span>
+                        {missing > 0 && <span className="ob1-status-pill not-started">누락 {missing}</span>}
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+
+              <div style={{ border: "1px solid #e2e8f0", borderRadius: "10px", padding: "16px", minHeight: "420px" }}>
+                {!selectedBatchId ? (
+                  <div style={{ height: "100%", display: "flex", alignItems: "center", justifyContent: "center", color: "#64748b" }}>
+                    왼쪽에서 요청을 선택하세요.
+                  </div>
+                ) : loadingDetail && !activeDetail ? (
+                  <div className="ob1-table-loading" style={{ padding: "24px" }}>
+                    <div className="ob1-spinner" />
+                    <p>요청 상세를 불러오고 있습니다.</p>
+                  </div>
+                ) : (
+                  <>
+                    <div style={{ display: "grid", gridTemplateColumns: "repeat(4, minmax(0, 1fr))", gap: "8px" }}>
+                      {[
+                        ["Batch", activeRequest.batchId || selectedBatchId],
+                        ["보고연도", activeRequest.reportingYear || "-"],
+                        ["요청 Metric", activeRequest.requestedMetricCount ?? activeRequest.metricCount ?? "-"],
+                        ["해결 Metric", activeRequest.resolvedMetricCount ?? "-"],
+                        ["승인 Atomic", activeRequest.currentApprovedAtomicCount ?? activeRequest.approvedAtomicCount ?? 0],
+                        ["누락 Atomic", currentMissingAtomicCount],
+                        ["준비", readinessLabel(activeRequest.readinessStatus)],
+                        ["전송", transferLabel(activeRequest.transferStatus)],
+                      ].map(([label, value]) => (
+                        <div key={label} style={{ padding: "10px", background: "#f8fafc", borderRadius: "8px" }}>
+                          <div style={{ fontSize: "0.72rem", color: "#64748b", marginBottom: "3px" }}>{label}</div>
+                          <div style={{ fontWeight: 700, color: "#0f172a" }}>{value}</div>
+                        </div>
+                      ))}
+                    </div>
+
+                    <div style={{ marginTop: "12px", fontSize: "0.82rem", color: "#475569" }}>
+                      승인 상태: {approvalLabel(activeRequest.approvalStatus)} · 범위: {activeRequest.metricScopeCode || "-"}
+                    </div>
+
+                    <MetricReadinessList
+                      title="직접 요청 Metric"
+                      items={activeDetail?.items || []}
                     />
-                    <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "4px" }}>
-                      <div style={{ fontWeight: 600, color: "#1e293b" }}>
-                        {req.parentCompanyName || "데이터 요청"}
+                    <MetricReadinessList
+                      title="계산 의존 Metric"
+                      description="Rollup 계산에 필요한 의존 입력입니다."
+                      items={activeDetail?.dependencyItems || []}
+                    />
+
+                    <div style={{ marginTop: "14px", padding: "12px", border: "1px solid #e2e8f0", borderRadius: "8px", background: "#f8fafc" }}>
+                      <strong>입력 Workspace</strong>
+                      <div style={{ fontSize: "0.82rem", color: "#475569", marginTop: "6px" }}>
+                        {inputWorkspace.availableYn
+                          ? `이동 가능: ${inputWorkspace.cycleType || "-"} / ${inputWorkspace.reportingYear || "-"}`
+                          : `준비 필요: ${inputWorkspace.reason || "INPUT_WORKSPACE_NOT_READY"}`}
                       </div>
-                      <div style={{ fontSize: "0.85rem", color: "#64748b" }}>
-                        보고연도: {req.reportingYear || "-"}
-                        {req.metricScopeCode && ` · 범위: ${req.metricScopeCode}`}
-                      </div>
-                      {isNotReady && (
-                        <div style={{ fontSize: "0.8rem", color: "#d97706", marginTop: "4px" }}>
-                          필수 항목 미완료로 전송 불가
-                          {req.missingAtomicMetricIds?.length > 0 && (
-                            <span style={{ display: "block", marginTop: "2px", fontSize: "0.75rem", color: "#92400e" }}>
-                              누락: {req.missingAtomicMetricIds.join(", ")}
-                            </span>
-                          )}
+                      {actionableInputMetricIds.length > 0 && (
+                        <div style={{ fontSize: "0.78rem", color: "#64748b", marginTop: "4px" }}>
+                          보완 대상: {actionableInputMetricIds.join(", ")}
                         </div>
                       )}
                     </div>
-                  </label>
-                );
-              })}
+                  </>
+                )}
+              </div>
             </div>
           )}
         </div>
@@ -202,8 +388,61 @@ const SubsidiaryTransferModal = ({ isOpen, onClose, onTransferred }) => {
             }}
             onClick={onClose}
           >
-            취소
+            닫기
           </button>
+
+          {currentMissingAtomicCount > 0 && inputWorkspace.availableYn === true && (
+            <button
+              style={{
+                padding: "8px 16px",
+                border: "1px solid #16a34a",
+                background: "#fff",
+                color: "#15803d",
+                borderRadius: "4px",
+                cursor: "pointer",
+              }}
+              onClick={handleNavigateInput}
+            >
+              입력 보완하기
+            </button>
+          )}
+
+          {currentMissingAtomicCount > 0 && inputWorkspace.availableYn !== true && selectedBatchId && (
+            <button
+              style={{
+                padding: "8px 16px",
+                border: "none",
+                background: "#94a3b8",
+                color: "#fff",
+                borderRadius: "4px",
+                cursor: "not-allowed",
+                opacity: 0.7,
+              }}
+              disabled
+              title={inputWorkspace.reason || "INPUT_WORKSPACE_NOT_READY"}
+            >
+              입력 workspace 준비 필요
+            </button>
+          )}
+
+          {currentMissingAtomicCount === 0 && !sendReadyYn && !isTransferred && selectedBatchId && (
+            <button
+              style={{
+                padding: "8px 16px",
+                border: "none",
+                background: "#94a3b8",
+                color: "#fff",
+                borderRadius: "4px",
+                cursor: "not-allowed",
+                opacity: 0.7,
+              }}
+              disabled
+              title="승인 완료 후 전송할 수 있습니다."
+            >
+              승인 완료 대기
+            </button>
+          )}
+
           <button
             style={{
               padding: "8px 16px",
@@ -217,7 +456,7 @@ const SubsidiaryTransferModal = ({ isOpen, onClose, onTransferred }) => {
             onClick={handleSend}
             disabled={!canSend}
           >
-            {sending ? "전송 중..." : "지주사에 전송하기"}
+            {isTransferred ? "전송 완료" : sending || sendingSource ? "전송 중..." : "지주사에 전송하기"}
           </button>
         </div>
       </div>
@@ -227,5 +466,3 @@ const SubsidiaryTransferModal = ({ isOpen, onClose, onTransferred }) => {
 };
 
 export default SubsidiaryTransferModal;
-
-

--- a/frontend/src/homes/onboards/modal/SubsidiaryTransferModal.jsx
+++ b/frontend/src/homes/onboards/modal/SubsidiaryTransferModal.jsx
@@ -272,6 +272,13 @@ const SubsidiaryTransferModal = ({
               <div style={{ display: "flex", flexDirection: "column", gap: "10px", maxHeight: "560px", overflow: "auto" }}>
                 {requests.map((req) => {
                   const missing = req.currentMissingAtomicCount ?? req.missingAtomicCount ?? req.missingAtomicMetricIds?.length ?? 0;
+                  const approved =
+                    req.currentApprovedAtomicCount ??
+                    req.approvedAtomicCount ??
+                    0;
+                  const required =
+                    req.requiredAtomicCount ??
+                    0;
                   return (
                     <button
                       key={req.batchId}
@@ -298,6 +305,7 @@ const SubsidiaryTransferModal = ({
                       <div style={{ display: "flex", gap: "6px", flexWrap: "wrap", marginTop: "8px" }}>
                         <span className="ob1-status-pill">{readinessLabel(req.readinessStatus)}</span>
                         <span className="ob1-status-pill">{transferLabel(req.transferStatus)}</span>
+                        <span className="ob1-status-pill">승인 Atomic {approved} / {required}</span>
                         {missing > 0 && <span className="ob1-status-pill not-started">누락 {missing}</span>}
                       </div>
                     </button>
@@ -353,7 +361,7 @@ const SubsidiaryTransferModal = ({
                       <strong>입력 Workspace</strong>
                       <div style={{ fontSize: "0.82rem", color: "#475569", marginTop: "6px" }}>
                         {inputWorkspace.availableYn
-                          ? `이동 가능: ${inputWorkspace.cycleType || "-"} / ${inputWorkspace.reportingYear || "-"}`
+                          ? `이동 가능: Cycle #${inputWorkspace.cycleId || "-"} · ${inputWorkspace.cycleType || "-"} · ${inputWorkspace.reportingYear || "-"}`
                           : `준비 필요: ${inputWorkspace.reason || "INPUT_WORKSPACE_NOT_READY"}`}
                       </div>
                       {actionableInputMetricIds.length > 0 && (

--- a/frontend/src/stores/reportSlice.js
+++ b/frontend/src/stores/reportSlice.js
@@ -76,6 +76,7 @@ const initialState = {
     projects: [],
     selectedProject: null,
     items: [],
+    selectedItemDetail: null,
     lastMutationResult: null,
     lastMutationError: null,
   },
@@ -99,6 +100,7 @@ const initialState = {
     unassignMetrics: false,
     approvalProjects: false,
     approvals: false,
+    approvalDetail: false,
     subsidiaries: false,
     rollupScopePreview: false,
     createBatch: false,
@@ -125,6 +127,7 @@ const initialState = {
     unassignMetrics: null,
     approvalProjects: null,
     approvals: null,
+    approvalDetail: null,
     subsidiaries: null,
     rollupScopePreview: null,
     createBatch: null,
@@ -365,6 +368,35 @@ export const fetchApprovalItems = createAsyncThunk(
       return rejectWithValue({
         status: false,
         message: "승인 작업함 조회 중 오류가 발생했습니다.",
+      });
+    }
+  }
+);
+
+export const fetchOnboardingApprovalDetail = createAsyncThunk(
+  "report/fetchOnboardingApprovalDetail",
+  async (
+    {
+      companyId,
+      reportingYear = DEFAULT_REPORTING_YEAR,
+      metricId,
+      cycleType = "PRE_DMA_G0",
+    },
+    { rejectWithValue }
+  ) => {
+    try {
+      const res = await GET(`${ONBOARDING_APPROVAL_API_ROOT}/detail`, {
+        companyId,
+        reportingYear,
+        metricId,
+        cycleType,
+      });
+      return rejectIfFailed(res, rejectWithValue, "온보딩 승인 상세 조회에 실패했습니다.");
+    } catch (error) {
+      console.error(error);
+      return rejectWithValue({
+        status: false,
+        message: "온보딩 승인 상세 조회 중 오류가 발생했습니다.",
       });
     }
   }
@@ -691,11 +723,17 @@ const reportSlice = createSlice({
     selectApprovalProject: (state, action) => {
       state.approval.selectedProject = action.payload ?? null;
       state.approval.items = [];
+      state.approval.selectedItemDetail = null;
     },
 
     clearApprovalProject: (state) => {
       state.approval.selectedProject = null;
       state.approval.items = [];
+      state.approval.selectedItemDetail = null;
+    },
+
+    clearApprovalDetail: (state) => {
+      state.approval.selectedItemDetail = null;
     },
   },
   extraReducers: (builder) => {
@@ -805,6 +843,21 @@ const reportSlice = createSlice({
       .addCase(fetchApprovalItems.rejected, (state, action) => {
         setRejected(state, "approvals", action);
         state.approval.items = [];
+      });
+
+    builder
+      .addCase(fetchOnboardingApprovalDetail.pending, (state) => {
+        setPending(state, "approvalDetail");
+        state.approval.selectedItemDetail = null;
+      })
+      .addCase(fetchOnboardingApprovalDetail.fulfilled, (state, action) => {
+        state.loading.approvalDetail = false;
+        state.error.approvalDetail = null;
+        state.approval.selectedItemDetail = dataOf(action.payload);
+      })
+      .addCase(fetchOnboardingApprovalDetail.rejected, (state, action) => {
+        setRejected(state, "approvalDetail", action);
+        state.approval.selectedItemDetail = null;
       });
 
     builder
@@ -989,6 +1042,7 @@ const reportSlice = createSlice({
 });
 
 export const {
+  clearApprovalDetail,
   clearApprovalProject,
   clearReportError,
   resetReportState,


### PR DESCRIPTION
## #️⃣연관된 이슈

> #156 #163  #161 #162 

## 📝작업 내용

**수정 파일**
frontend/src/homes/mains/ManagerData.jsx
backend/src/services/onboardings/service.py
backend/src/utils/onboardingapprovalrepository.py
backend/tests/test_onboardingapprovaldetail.py
backend/tests/test_onboardingapprovalreview.py
frontend/src/homes/mains/DataTab.jsx

**3. REVIEWED frontend 매핑 보정**
ManagerData.jsx의 reviewStatus 계산식에서 REVIEWED 상태를 포함하도록 보정했습니다.

javascript
reviewStatus: [
  "REVIEWED",
  "APPROVED",
  "REJECTED",
].includes(approvalStatus)
  ? "REVIEWED"
  : "PENDING",

**4. 컨설턴트 reject 권한 보정**
service.py의 rejectApproval() 함수에서 checkApprover 대신 checkReviewer를 사용하여 컨설턴트도 반려할 수 있도록 수정했습니다.

**5. approve 권한 유지 확인**
approveApproval() 함수는 기존의 checkApprover를 유지하여 컨설턴트가 최종 승인할 수 없도록 권한을 분리했습니다.

**6. Atomic detail onboarding_input_yn 필터**
onboardingapprovalrepository.py의 listApprovalAtomicDetailRows()에서 master.get("onboarding_input_yn") 값이 Truthy하지 않은 항목은 상세 조회 대상에서 건너뛰도록 추가했습니다. 이를 통해 DERIVED/결과용 Atomic이 Modal에서 제외됩니다.

**7. Repository 필터 테스트**
test_onboardingapprovaldetail.py에 신규 테스트 test_repository_excludes_non_input_atomic_items를 추가하여 onboarding_input_yn 값이 0인 항목이 정상적으로 제외되는지 확인했으며, 기존 Fixture들에도 해당 필드를 추가했습니다.

**8. Consultant reject 권한 테스트**
test_onboardingapprovalreview.py에 OnboardingApprovalReviewServiceTest 테스트 클래스를 추가하여 rejectApproval에선 컨설턴트가 허용되고 일반 사원은 차단되는지, approveApproval에선 컨설턴트가 차단되는지를 검증하는 단위 테스트를 보강했습니다.

**9. DataTab checkbox loading 정합성**
DataTab.jsx 내 체크박스 요소의 disabled 속성을 disabled={readOnlyYn || actionLoading}으로 변경하여, Mutation(API 요청) 진행 중에 체크박스가 클릭되지 않도록 UI를 보완했습니다.