### PR TITLE
미디어 PG 모드 설문 폼 자동생성 · KCGS 입력 저장 · 응답 임포트 멱등화 

### DIFF
--- a/backend/src/apis/media.py
+++ b/backend/src/apis/media.py
@@ -6,10 +6,12 @@ from src.models.media import (
     MediaNewsCrawlAnalyzeRequest,
     MediaNewsCrawlAnalyzeResponse,
 )
+from src.models.dmakcgsgrade import KcgsGradeSaveRequest, KcgsGradeSaveResponse
 from src.services.medias.service import (
     buildMediaAnalyzeResponse,
     runMediaAnalysis,
     runMediaCrawlAndAnalyze,
+    saveKcgsGradeInputs,
 )
 from src.utils.auth import get_token
 
@@ -45,6 +47,25 @@ async def crawl_and_analyze_media_news(
 ):
     try:
         return runMediaCrawlAndAnalyze(request, userModel)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/kcgs/grades",
+    response_model=KcgsGradeSaveResponse,
+    summary="KCGS ESG 등급 입력 저장(APPROVED)",
+)
+async def save_kcgs_grades(request: KcgsGradeSaveRequest, userModel=Depends(get_token)):
+    try:
+        saved = saveKcgsGradeInputs(request, userModel)
+        return KcgsGradeSaveResponse(
+            companyId=request.companyId,
+            savedCount=saved,
+            reviewStatus="APPROVED",
+        )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:

--- a/backend/src/models/dmakcgsgrade.py
+++ b/backend/src/models/dmakcgsgrade.py
@@ -1,0 +1,31 @@
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class KcgsGradeRowDto(BaseModel):
+    """모달에서 입력하는 단일 연도 KCGS 등급 행."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    ratingYear: int = Field(..., ge=2000, le=2100)
+    overallGrade: str = Field(..., min_length=1)
+    environmentGrade: str = Field(..., min_length=1)
+    socialGrade: str = Field(..., min_length=1)
+    governanceGrade: str = Field(..., min_length=1)
+    sourceDocumentRef: Optional[str] = None
+
+
+class KcgsGradeSaveRequest(BaseModel):
+    """KCGS 등급 저장 요청. 점수 반영을 위해 정확히 3개 연속 연도가 필요하다."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    companyId: int = Field(..., gt=0)
+    grades: List[KcgsGradeRowDto]
+
+
+class KcgsGradeSaveResponse(BaseModel):
+    companyId: int
+    savedCount: int
+    reviewStatus: str

--- a/backend/src/services/medias/service.py
+++ b/backend/src/services/medias/service.py
@@ -36,7 +36,11 @@ from src.utils.dmarepository import (
     step4ReplaceRegulationShadowTracesTx,
     listExternalMaxEligibleMediaRows,
     step4ReplaceMediaExternalMaxShadowAndSummaryTx,
+    countTop20RankedSubIssues,
+    saveKcgsGradeInputRows,
 )
+from src.models.dmaengine import KcgsGradeInputV13
+from src.models.dmakcgsgrade import KcgsGradeSaveRequest
 from src.utils.dmascoring import SCORE_UI_MULTIPLIER, scoreSignals
 from src.utils.dmaworkflowrepository import upsertDmaWorkflowStatus
 from src.utils.subissuemaster import getSubIssueDisplayName
@@ -175,48 +179,118 @@ def buildMediaAnalyzeResponse(
 
 
 def _runMediaCrawlAndAnalyzePg(request: MediaNewsCrawlAnalyzeRequest) -> MediaNewsCrawlAnalyzeResponse:
-    scoredSignals = runMediaAnalysis(
-        articles=[],
-        runId=request.runId,
-        keywords=MVP_DEMO_COMPANY_KEYWORDS,
-        industryKeywords=MVP_DEMO_INDUSTRY_KEYWORDS,
-        shadowReplaceYn=True,
-        usePgPipeline=True,
+    runId = request.runId
+    currentStage = "PREPARE"
+    currentProgress = 10
+    _writeMediaWorkflowStatus(
+        runId=runId,
+        overallStatus="RUNNING",
+        currentStage=currentStage,
+        progressPercent=currentProgress,
+        startedYn=True,
     )
 
-    # Regulation/KCGS shadow refresh: best-effort, 실패해도 분석 결과는 보존한다.
-    # ExternalMax/Summary/Final/Rank는 materiality 전체 사이클 완료 후에만 유효하므로
-    # PG 모드에서는 호출하지 않는다.
     try:
-        refreshRegulationShadowForRun(request.runId)
-    except Exception as _exc:
-        print(f"Warning: [pg_media] regulation shadow refresh skipped: {_exc}")
-    try:
-        refreshKcgsShadowForRun(request.runId)
-    except Exception as _exc:
-        print(f"Warning: [pg_media] kcgs shadow refresh skipped: {_exc}")
+        currentStage = "NEWS_ANALYSIS"
+        currentProgress = 55
+        _writeMediaWorkflowStatus(
+            runId=runId,
+            overallStatus="RUNNING",
+            currentStage=currentStage,
+            progressPercent=currentProgress,
+        )
+        scoredSignals = runMediaAnalysis(
+            articles=[],
+            runId=request.runId,
+            keywords=MVP_DEMO_COMPANY_KEYWORDS,
+            industryKeywords=MVP_DEMO_INDUSTRY_KEYWORDS,
+            shadowReplaceYn=True,
+            usePgPipeline=True,
+        )
 
-    coverageInfo = getMediaCoverage(request.runId)
-    savedSignalCount = len(scoredSignals) if scoredSignals else 0
+        # Regulation/KCGS shadow refresh: best-effort, 실패해도 분석 결과는 보존한다.
+        # ExternalMax/Summary/Final/Rank는 materiality 전체 사이클 완료 후에만 유효하므로
+        # PG 모드에서는 재계산하지 않는다(기존 랭크를 그대로 사용).
+        currentStage = "REGULATION_REFRESH"
+        currentProgress = 70
+        _writeMediaWorkflowStatus(
+            runId=runId,
+            overallStatus="RUNNING",
+            currentStage=currentStage,
+            progressPercent=currentProgress,
+        )
+        try:
+            refreshRegulationShadowForRun(request.runId)
+        except Exception as _exc:
+            print(f"Warning: [pg_media] regulation shadow refresh skipped: {_exc}")
 
-    return MediaNewsCrawlAnalyzeResponse(
-        runId=request.runId,
-        requestedSources=request.sources,
-        allowedSources=request.sources,
-        rejectedSources=[],
-        companyKeywords=MVP_DEMO_COMPANY_KEYWORDS,
-        industryKeywords=MVP_DEMO_INDUSTRY_KEYWORDS,
-        collectedArticleCount=0,
-        filteredArticleCount=0,
-        articleCount=0,
-        savedSignalCount=savedSignalCount,
-        observedSubIssueCount=countMediaSubIssues(request.runId),
-        sourceBreakdown=[],
-        topIssues=_buildMediaTopIssues(request.runId),
-        coverage=coverageInfo,
-        coverageStatus=coverageInfo["coverageStatus"],
-        errors=[],
-    )
+        currentStage = "KCGS_REFRESH"
+        currentProgress = 80
+        _writeMediaWorkflowStatus(
+            runId=runId,
+            overallStatus="RUNNING",
+            currentStage=currentStage,
+            progressPercent=currentProgress,
+        )
+        try:
+            refreshKcgsShadowForRun(request.runId)
+        except Exception as _exc:
+            print(f"Warning: [pg_media] kcgs shadow refresh skipped: {_exc}")
+
+        # PG 모드는 External MAX/Rank 를 재계산하지 않지만, 전체 사이클에서 이미 산정된
+        # 랭크가 있으면 그 기준으로 설문 폼(Top20, 최대 20개)을 생성한다.
+        # 랭크가 0개면(아직 산정 전) 폼 생성을 건너뛰고 분석은 정상 완료시킨다.
+        if countTop20RankedSubIssues(request.runId) >= 1:
+            currentStage = "SURVEY_FORM_FREEZE"
+            currentProgress = 95
+            _writeMediaWorkflowStatus(
+                runId=runId,
+                overallStatus="RUNNING",
+                currentStage=currentStage,
+                progressPercent=currentProgress,
+            )
+            ensureSurveyFormForRun(request.runId)
+
+        coverageInfo = getMediaCoverage(request.runId)
+        savedSignalCount = len(scoredSignals) if scoredSignals else 0
+
+        response = MediaNewsCrawlAnalyzeResponse(
+            runId=request.runId,
+            requestedSources=request.sources,
+            allowedSources=request.sources,
+            rejectedSources=[],
+            companyKeywords=MVP_DEMO_COMPANY_KEYWORDS,
+            industryKeywords=MVP_DEMO_INDUSTRY_KEYWORDS,
+            collectedArticleCount=0,
+            filteredArticleCount=0,
+            articleCount=0,
+            savedSignalCount=savedSignalCount,
+            observedSubIssueCount=countMediaSubIssues(request.runId),
+            sourceBreakdown=[],
+            topIssues=_buildMediaTopIssues(request.runId),
+            coverage=coverageInfo,
+            coverageStatus=coverageInfo["coverageStatus"],
+            errors=[],
+        )
+
+        currentStage = "COMPLETED"
+        currentProgress = 100
+        _writeMediaWorkflowStatus(
+            runId=runId,
+            overallStatus="COMPLETED",
+            currentStage=currentStage,
+            progressPercent=currentProgress,
+            completedYn=True,
+        )
+        return response
+    except Exception as e:
+        _recordMediaWorkflowFailureBestEffort(
+            runId=runId,
+            currentStage=currentStage,
+            progressPercent=currentProgress,
+            error=e,
+        )
+        raise
 
 
 def runMediaCrawlAndAnalyze(
@@ -336,7 +410,27 @@ def runMediaCrawlAndAnalyze(
             )
             # media_external External MAX Shadow + Summary + Final + Rank — critical path.
             refreshMediaExternalMaxForRun(request.runId)
-            ensureSurveyFormForRun(request.runId)
+            # 폼은 랭크가 1개 이상일 때만 생성한다. 이번 run 의 신호가 비어
+            # refresh 결과 랭크가 0개로 재계산되면(크롤 0건 + 규제/KCGS 미승인 등),
+            # 폼 생성을 건너뛰고 미디어 분석은 정상 완료시킨다.
+            # (got 0 으로 미디어 워크플로 전체를 FAILED 시키지 않는다.)
+            if countTop20RankedSubIssues(request.runId) >= 1:
+                ensureSurveyFormForRun(request.runId)
+        else:
+            # 크롤 미완료(기사 0건 등)로 External MAX 재계산은 건너뛰지만,
+            # 이미 랭크된 서브이슈가 있으면 그 기존 랭크 기준으로 설문 폼을 생성한다.
+            # Top20 은 최대 20개이며, 20개 미만이어도 현재 랭크 기준으로 생성한다.
+            # (점수는 덮어쓰지 않고, 폼 freeze 만 별도로 수행)
+            if countTop20RankedSubIssues(request.runId) >= 1:
+                currentStage = "SURVEY_FORM_FREEZE"
+                currentProgress = 95
+                _writeMediaWorkflowStatus(
+                    runId=runId,
+                    overallStatus="RUNNING",
+                    currentStage=currentStage,
+                    progressPercent=currentProgress,
+                )
+                ensureSurveyFormForRun(request.runId)
 
         sourceBreakdown = applySavedSignalCounts(
             crawlResult.sourceBreakdown,
@@ -511,6 +605,58 @@ def refreshKcgsShadowForRun(runId: int) -> int:
     payloads = step2BuildKcgsPillarBoostPayloads(gradeRows)
 
     return step4ReplaceKcgsShadowTracesTx(runId, payloads)
+
+
+def saveKcgsGradeInputs(request: KcgsGradeSaveRequest, userModel) -> int:
+    """
+    모달에서 입력한 KCGS 등급(정확히 3개 연속 연도)을 APPROVED 로 저장한다.
+    저장 전, 미디어 분석이 실제로 쓰는 동일 빌더(step2BuildKcgsPillarBoostPayloads)로
+    fail-closed 검증한다. (3개·연속연도·단일회사·유효등급) 검증 통과 시에만 DB 반영.
+    이후 미디어 분석을 다시 실행하면 refreshKcgsShadowForRun 이 이 행들을 읽어 점수에 반영한다.
+    """
+    if len(request.grades) != 3:
+        raise ValueError("KCGS 등급은 정확히 3개년(연속) 입력이 필요합니다.")
+
+    inputs = [
+        KcgsGradeInputV13(
+            companyId=request.companyId,
+            ratingYear=g.ratingYear,
+            overallGrade=g.overallGrade,
+            environmentGrade=g.environmentGrade,
+            socialGrade=g.socialGrade,
+            governanceGrade=g.governanceGrade,
+            inputSourceType="MANUAL",
+            sourceDocumentRef=g.sourceDocumentRef,
+            reviewStatus="APPROVED",
+        )
+        for g in request.grades
+    ]
+
+    # 저장 전 검증: 등급 유효성/연속연도/3개/단일회사 — 실패 시 ValueError -> 400
+    step2BuildKcgsPillarBoostPayloads(inputs)
+
+    if isinstance(userModel, dict):
+        userId = userModel.get("id")
+    else:
+        userId = getattr(userModel, "id", None)
+
+    rows = [
+        {
+            "ratingYear": g.ratingYear,
+            "overallGrade": g.overallGrade,
+            "environmentGrade": g.environmentGrade,
+            "socialGrade": g.socialGrade,
+            "governanceGrade": g.governanceGrade,
+            "sourceDocumentRef": g.sourceDocumentRef,
+        }
+        for g in request.grades
+    ]
+    return saveKcgsGradeInputRows(
+        companyId=request.companyId,
+        rows=rows,
+        reviewStatus="APPROVED",
+        createdByUserId=userId,
+    )
 
 
 def _isCrawlComplete(crawlResult) -> bool:

--- a/backend/src/utils/dmarepository.py
+++ b/backend/src/utils/dmarepository.py
@@ -437,6 +437,24 @@ def updateRanks(runId: int):
     from src.utils.db import saveMany
     saveMany(updateSql, params)
 
+def countTop20RankedSubIssues(runId: int) -> int:
+    """
+    설문 폼이 freeze 하는 Top20 스냅샷과 '동일한' 조건으로 랭크된 서브이슈 수를 센다.
+    (ESG_SUB_ISSUE_MASTER INNER JOIN + rank_no IS NOT NULL)
+    폼은 정확히 20개를 요구하므로, 이 값이 20 이상이면 폼 생성이 가능하다.
+    dmasurveyformrepository._TOP20_SQL 과 조인/조건이 일치해야 한다.
+    """
+    sql = """
+        SELECT COUNT(*) AS cnt
+        FROM ESG_DMA_SCORE_SUMMARY s
+        INNER JOIN ESG_SUB_ISSUE_MASTER m
+                ON m.sub_issue_code = s.sub_issue_code
+        WHERE s.esg_materiality_run_id = ?
+          AND s.rank_no IS NOT NULL
+    """
+    row = findOne(sql, (runId,))
+    return int(row["cnt"]) if row and row.get("cnt") is not None else 0
+
 def upsertFinal(runId: int, score: FinalMaterialityScore):
     sql = """
         INSERT INTO ESG_DMA_SCORE_SUMMARY (
@@ -1924,6 +1942,56 @@ def listApprovedKcgsGradeInputs(companyId: int) -> list[dict]:
         LIMIT 3
     """
     return _findAllRegulationRowsOrRaise(sql, (companyId,))
+
+
+def saveKcgsGradeInputRows(
+    companyId: int,
+    rows: Sequence[Dict[str, Any]],
+    reviewStatus: str = "APPROVED",
+    createdByUserId: Optional[int] = None,
+) -> int:
+    """
+    KCGS 등급 입력을 (company_id, rating_year) 기준으로 UPSERT 한다.
+    unique key uk_dma_kcgs_grade_company_year 가 있어 동일 연도는 갱신된다.
+    rows 각 항목 키: ratingYear, overallGrade, environmentGrade, socialGrade,
+                    governanceGrade, sourceDocumentRef(optional)
+    """
+    if not rows:
+        return 0
+    sql = """
+        INSERT INTO ESG_DMA_KCGS_GRADE_INPUT
+            (company_id, rating_year, overall_grade, environment_grade,
+             social_grade, governance_grade, source_type, source_document_ref,
+             review_status, created_by_user_id, delete_yn)
+        VALUES (?, ?, ?, ?, ?, ?, 'MANUAL', ?, ?, ?, 0)
+        ON DUPLICATE KEY UPDATE
+            overall_grade = VALUES(overall_grade),
+            environment_grade = VALUES(environment_grade),
+            social_grade = VALUES(social_grade),
+            governance_grade = VALUES(governance_grade),
+            source_type = VALUES(source_type),
+            source_document_ref = VALUES(source_document_ref),
+            review_status = VALUES(review_status),
+            created_by_user_id = VALUES(created_by_user_id),
+            delete_yn = 0
+    """
+    params = [
+        (
+            companyId,
+            int(row["ratingYear"]),
+            row["overallGrade"],
+            row["environmentGrade"],
+            row["socialGrade"],
+            row["governanceGrade"],
+            row.get("sourceDocumentRef"),
+            reviewStatus,
+            createdByUserId,
+        )
+        for row in rows
+    ]
+    from src.utils.db import saveMany
+    saveMany(sql, params)
+    return len(params)
 
 
 def _buildKcgsShadowRows(

--- a/backend/src/utils/dmasurveyformrepository.py
+++ b/backend/src/utils/dmasurveyformrepository.py
@@ -185,11 +185,13 @@ def getOrFreezeSurveyFormSnapshotTx(*, runId: int, templateVersion: str) -> dict
             cur.execute(_TOP20_SQL, (runId,))
             rows = cur.fetchall()
 
-        if len(rows) != 20:
+        # Top20 = 최대 20개(쿼리 LIMIT 20). 20개 미만이어도 현재 랭크 기준으로 폼을 생성한다.
+        # 단, 랭크된 서브이슈가 하나도 없으면(0개) 폼을 만들 수 없으므로 실패시킨다.
+        if not rows:
             conn.rollback()
             raise RuntimeError(
-                f"Top20 snapshot requires exactly 20 rows with rank_no IS NOT NULL,"
-                f" got {len(rows)} for runId={runId}"
+                f"Top20 snapshot requires at least 1 row with rank_no IS NOT NULL,"
+                f" got 0 for runId={runId}"
             )
 
         codes_seen = set()

--- a/backend/src/utils/dmasurveyresponserepository.py
+++ b/backend/src/utils/dmasurveyresponserepository.py
@@ -35,6 +35,15 @@ INSERT INTO ESG_DMA_SURVEY_RESPONSE (
     delete_yn
 )
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
+ON DUPLICATE KEY UPDATE
+    esg_materiality_run_id = VALUES(esg_materiality_run_id),
+    mapped_axis = VALUES(mapped_axis),
+    respondent_user_id = VALUES(respondent_user_id),
+    department_code = VALUES(department_code),
+    answer_numeric = VALUES(answer_numeric),
+    answer_text = VALUES(answer_text),
+    normalized_score = VALUES(normalized_score),
+    delete_yn = 0
 """
 
 

--- a/frontend/src/homes/reports/Media.jsx
+++ b/frontend/src/homes/reports/Media.jsx
@@ -12,6 +12,7 @@ import {
   fetchDmaWorkflowStatus,
   selectCanRunDmaStage,
   selectDmaGateReason,
+  saveKcgsGrades,
 } from "@stores/reportSlice";
 
 // 정적 데이터 정의 (컴포넌트 외부에 두어 불필요한 재렌더링 방지)
@@ -252,10 +253,32 @@ const Media = () => {
     }));
   };
 
-  const handleKcgsSubmit = () => {
-    setIsKcgsModalOpen(false);
-    if (!selectedInstitutions.includes("kcgs")) {
-      setSelectedInstitutions(prev => [...prev, "kcgs"]);
+  const handleKcgsSubmit = async () => {
+    if (!companyId) {
+      showDefaultAlert("저장 불가", "회사 정보를 찾을 수 없습니다. 다시 로그인해주세요.", "warning");
+      return;
+    }
+    // 모달 grades(year/total/e/s/g) → 백엔드 DTO(ratingYear/overallGrade/...) 로 매핑
+    const grades = kcgsData.grades.map((g) => ({
+      ratingYear: Number(g.year),
+      overallGrade: g.total,
+      environmentGrade: g.e,
+      socialGrade: g.s,
+      governanceGrade: g.g,
+    }));
+    try {
+      await dispatch(saveKcgsGrades({ companyId, grades })).unwrap();
+      setIsKcgsModalOpen(false);
+      if (!selectedInstitutions.includes("kcgs")) {
+        setSelectedInstitutions((prev) => [...prev, "kcgs"]);
+      }
+      showDefaultAlert(
+        "저장 완료",
+        "KCGS 등급이 저장되었습니다. 미디어 분석 실행 시 점수에 반영됩니다.",
+        "success"
+      );
+    } catch (err) {
+      showDefaultAlert("저장 실패", err?.message || "KCGS 등급 저장에 실패했습니다.", "error");
     }
   };
 

--- a/frontend/src/stores/reportSlice.js
+++ b/frontend/src/stores/reportSlice.js
@@ -932,6 +932,24 @@ export const runMediaCrawlAndAnalyze = createAsyncThunk(
   }
 );
 
+// KCGS ESG 등급 입력 저장(APPROVED). 정확히 3개 연속 연도 grades 를 전송한다.
+// 저장 성공 후 미디어 분석을 다시 실행하면 KCGS pillar boost 가 점수에 반영된다.
+export const saveKcgsGrades = createAsyncThunk(
+  "report/saveKcgsGrades",
+  async ({ companyId, grades }, { rejectWithValue }) => {
+    try {
+      const res = await POST("/media/kcgs/grades", { companyId, grades });
+      return rejectIfFailed(res, rejectWithValue, "KCGS 등급 저장에 실패했습니다.");
+    } catch (error) {
+      console.error(error);
+      return rejectWithValue({
+        status: false,
+        message: apiErrorMessage(error, "KCGS 등급 저장 중 오류가 발생했습니다."),
+      });
+    }
+  }
+);
+
 export const fetchMediaResult = createAsyncThunk(
   "report/fetchMediaResult",
   async ({ runId }, { rejectWithValue }) => {


### PR DESCRIPTION
(#250)


**요약**
PG 파이프라인 모드에서 미디어 분석을 실행해도 설문 폼이 자동 생성되지 않던 문제를 해결하고, KCGS 등급 입력 저장 경로를 신설했으며, 설문 응답 임포트를 멱등하게 만들었습니다.

**변경 사항**
1. 미디어(PG 모드) 분석 → 설문 폼 자동 생성

프론트가 실제로 타는 경로(_runMediaCrawlAndAnalyzePg)에 폼 생성 호출(ensureSurveyFormForRun)이 누락돼 있었음 → 추가
MEDIA 워크플로 진행 상태(ESG_DMA_WORKFLOW_STATUS) 기록도 누락 → PREPARE→…→COMPLETED 단계별 기록 추가 (프론트 폴링 정상화)
가드: 랭크된 서브이슈가 1개 이상일 때만 폼 생성, 0개면 스킵하고 분석은 정상 완료 (전체 FAILED 방지)
2. Top20 스냅샷 freeze 조건 완화

기존: 랭크 정확히 20개여야 폼 생성(미만이면 실패) → 1개 이상이면 생성(최대 20, LIMIT 20 유지)
3. KCGS 등급 입력 저장 경로 신설 (모달 → API → DB → 점수 반영)

기존: KCGS 점수 산식은 있으나 입력을 저장하는 경로가 없어 항상 0으로 반영됨
신규 엔드포인트 POST /media/kcgs/grades — 3개년 연속 등급을 검증 후 APPROVED로 UPSERT
저장 전 분석과 동일한 빌더로 fail-closed 검증(연속연도·유효등급·3개)
프론트 KCGS 모달 "입력 완료" → 실제 저장 연결
4. 설문 응답 임포트 멱등화

**변경 파일**
backend/src/services/medias/service.py            PG 폼생성 + status + 가드
backend/src/utils/dmarepository.py                countTop20RankedSubIssues, KCGS UPSERT
backend/src/utils/dmasurveyformrepository.py      Top20 freeze 조건 완화
backend/src/utils/dmasurveyresponserepository.py  응답 임포트 멱등화
backend/src/apis/media.py                         KCGS 저장 엔드포인트
backend/src/models/dmakcgsgrade.py                (신규) KCGS 요청/응답 DTO
frontend/src/homes/reports/Media.jsx              KCGS 모달 저장 연결
frontend/src/stores/reportSlice.js                saveKcgsGrades thunk

**검증**
백엔드 컴파일 OK / 프론트 빌드 OK
PG 함수 직접 실행 → 폼 생성(READY + 구글폼 URL) + MEDIA status COMPLETED 확인
최신 skm_test(#249) 머지 충돌 0건
참고 / 주의
보호 산식 미변경: scoring/aggregator/formservice 로직은 안 건드림. dmasurveyformrepository는 freeze 조건 1줄(정확히 20 → 1개 이상)만 변경
DB 동작 변경 주의: 응답 임포트가 중복을 에러 대신 병합(last-wins) 으로 처리함 → 원본 시트에 의도치 않은 중복이 있으면 조용히 합쳐짐
운영 반영 시: USE_PG_PIPELINE 환경에서 PG 경로가 폼을 생성하므로, 기존 랭크(전체 materiality 사이클 산정분)가 있어야 폼이 생성됨
backend/.env(FILE_DIR/GEMINI_MODEL) 변경은 로컬 전용이라 커밋에 미포함